### PR TITLE
ghc-7.6 

### DIFF
--- a/Codec/Picture.hs
+++ b/Codec/Picture.hs
@@ -68,7 +68,7 @@ module Codec.Picture (
 
 import Control.Applicative( (<$>) )
 import Control.DeepSeq( NFData, deepseq )
-import Control.Exception( catch, IOException )
+import qualified Control.Exception as Exc ( catch, IOException )
 import Codec.Picture.Bitmap( BmpEncodable, decodeBitmap
                            , writeBitmap, encodeBitmap
                            , encodeDynamicBitmap, writeDynamicBitmap )
@@ -79,7 +79,7 @@ import Codec.Picture.Gif( decodeGif, decodeGifImages )
 import Codec.Picture.Saving
 import Codec.Picture.Types
 import System.IO ( withFile, IOMode(ReadMode) )
-import Prelude hiding(catch)
+
 
 import qualified Data.ByteString as B
 
@@ -94,8 +94,8 @@ eitherLoad v = inner ""
 withImageDecoder :: (NFData a)
                  => (B.ByteString -> Either String a) -> FilePath
                  -> IO (Either String a)
-withImageDecoder decoder path = catch doit
-                    (\e -> return . Left $ show (e :: IOException))
+withImageDecoder decoder path = Exc.catch doit
+                    (\e -> return . Left $ show (e :: Exc.IOException))
     where doit = withFile path ReadMode $ \h ->
                     force . decoder <$> B.hGetContents h
           -- force appeared in deepseq 1.3, Haskell Platform

--- a/JuicyPixels.cabal
+++ b/JuicyPixels.cabal
@@ -33,7 +33,7 @@ Executable imageTest
   Ghc-options: -O3 -Wall
   -- -cpp -prof -auto-all -rtsopts -caf-all -fforce-recomp
   Build-depends: base                >= 4       && < 5,
-                 bytestring          >= 0.9     && < 0.10,
+                 bytestring          >= 0.9     && < 0.11,
                  mtl                 >= 1.1     && < 2.2,
                  cereal              >= 0.3.3.0 && < 0.4,
                  zlib                >= 0.5.3.1 && < 0.6,
@@ -56,7 +56,7 @@ Library
 
   Ghc-options: -O3 -Wall
   Build-depends: base                >= 4       && < 5,
-                 bytestring          >= 0.9     && < 0.10,
+                 bytestring          >= 0.9     && < 0.11,
                  mtl                 >= 1.1     && < 2.2,
                  cereal              >= 0.3.3.0 && < 0.4,
                  zlib                >= 0.5.3.1 && < 0.6,


### PR DESCRIPTION
For ghc-7.6 Pictures.hs needs not to presuppose that Prelude exports catch, so I imported `catch` and `IOException` you wanted qualified.  ghc-7.6 needs bytestring-0.10.0.0 so I bumped the upper limit in the .cabal file, which seemed no problem. Awesome library, by the way.
