### PR TITLE
Small tweaks allowing JuicyPixels to build in older environments

### DIFF
--- a/JuicyPixels.cabal
+++ b/JuicyPixels.cabal
@@ -84,7 +84,7 @@ Library
                  vector              >= 0.9    && < 0.11,
                  primitive           >= 0.5     && < 0.6,
                  deepseq             >= 1.1     && < 1.4,
-                 containers          >= 0.5     && < 0.6
+                 containers          >= 0.4.2   && < 0.6
 
   if flag(Mmap)
     Build-depends: mmap

--- a/src/Codec/Picture/Gif/LZWEncoding.hs
+++ b/src/Codec/Picture/Gif/LZWEncoding.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BangPatterns, CPP #-}
 module Codec.Picture.Gif.LZWEncoding( lzwEncode ) where
 
 import Control.Applicative( (<$>) )
@@ -7,7 +7,11 @@ import qualified Data.ByteString.Lazy as L
 import Data.Maybe( fromMaybe )
 import Data.Monoid( mempty )
 import Data.Word( Word8 )
+#if MIN_VERSION_containers(0,5,0)
 import qualified Data.IntMap.Strict as I
+#else
+import qualified Data.IntMap as I
+#endif
 import qualified Data.Vector.Storable as V
 
 import Codec.Picture.BitWriter


### PR DESCRIPTION
Probably JuicyPixels already builds under GHC 7.4.2 by itself; but when built in conjunction with things that depend on the `ghc` package, (as e.g. a dependency of diagrams) we need to allow older versions of GHC boot packages such as `Cabal` and `containers`.
