### PR TITLE
Language pragmas needed by GHC HEAD (v7.9)

### DIFF
--- a/src/Codec/Picture/ColorQuant.hs
+++ b/src/Codec/Picture/ColorQuant.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
 -- | This module provide some color quantisation algorithm
 -- in order to help in the creation of paletted images.
 -- The most important function is `palettize` which will

--- a/src/Codec/Picture/Gif.hs
+++ b/src/Codec/Picture/Gif.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 -- | Module implementing GIF decoding.
 module Codec.Picture.Gif ( -- * Reading
                            decodeGif

--- a/src/Codec/Picture/HDR.hs
+++ b/src/Codec/Picture/HDR.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE TypeFamilies #-}
 -- | Module dedicated of Radiance file decompression (.hdr or .pic) file.
 -- Radiance file format is used for High dynamic range imaging.
 module Codec.Picture.HDR( decodeHDR, encodeHDR, writeHDR ) where

--- a/src/Codec/Picture/Jpg/Common.hs
+++ b/src/Codec/Picture/Jpg/Common.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE TypeFamilies #-}
 module Codec.Picture.Jpg.Common
     ( DctCoefficients
     , JpgUnpackerParameter( .. )

--- a/src/Codec/Picture/Jpg/FastDct.hs
+++ b/src/Codec/Picture/Jpg/FastDct.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 module Codec.Picture.Jpg.FastDct( referenceDct, fastDctLibJpeg ) where
 
 import Control.Applicative( (<$>) )

--- a/src/Codec/Picture/Jpg/FastIdct.hs
+++ b/src/Codec/Picture/Jpg/FastIdct.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
 -- | Module providing a 'fast' implementation of IDCT
 --
 -- inverse two dimensional DCT, Chen-Wang algorithm       

--- a/src/Codec/Picture/Jpg/Types.hs
+++ b/src/Codec/Picture/Jpg/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
 module Codec.Picture.Jpg.Types( MutableMacroBlock
                               , createEmptyMutableMacroBlock
                               , printMacroBlock

--- a/src/Codec/Picture/Png.hs
+++ b/src/Codec/Picture/Png.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE TypeFamilies #-}
 -- | Module used for loading & writing \'Portable Network Graphics\' (PNG)
 -- files.
 --


### PR DESCRIPTION
These pragmas are necessary to compile with bleeding edge GHC. Similar changes were needed to many libs, in order to get e.g. `arithmoi` etc. compilable.

_Note:_ unfortunately `src/Codec/Picture/Png.hs` does not build yet, due to (allegedly) illegal use of runST. Not sure whether this is a Juicy or GHC bug.
