### PR TITLE
Use transformers-compat to get ExceptT with older transformers versions.

### DIFF
--- a/JuicyPixels.cabal
+++ b/JuicyPixels.cabal
@@ -92,6 +92,7 @@ Library
                  binary              >= 0.5     && < 0.8,
                  zlib                >= 0.5.3.1 && < 0.6,
                  transformers        >= 0.2,
+                 transformers-compat == 0.3.*,
                  vector              >= 0.9     && < 0.11,
                  primitive           >= 0.4     && < 0.6,
                  deepseq             >= 1.1     && < 1.5,

--- a/src/Codec/Picture/HDR.hs
+++ b/src/Codec/Picture/HDR.hs
@@ -41,20 +41,7 @@ import Codec.Picture.InternalHelper
 import Codec.Picture.Types
 import Codec.Picture.VectorByteConversion
 
-#if MIN_VERSION_transformers(0, 4, 0)
 import Control.Monad.Trans.Except( ExceptT, throwE, runExceptT )
-#else
--- Transfomers 0.3 compat
-import Control.Monad.Trans.Error( Error, ErrorT, throwError, runErrorT )
-
-type ExceptT = ErrorT
-
-throwE :: (Monad m, Error e) => e -> ErrorT e m a
-throwE = throwError
-
-runExceptT :: ErrorT e m a -> m (Either e a)
-runExceptT = runErrorT
-#endif
 
 {-# INLINE (.<<.) #-}
 (.<<.), (.>>.) :: (Bits a) => a -> Int -> a


### PR DESCRIPTION
Since this package doesn't define ExceptT instances and doesn't export anything related to ExceptT this simply removes some duplication.

Also see https://github.com/fpco/stackage/issues/439
