### PR TITLE
Fix calculated bitmap size for PixelRGB8

### DIFF
--- a/src/Codec/Picture/Bitmap.hs
+++ b/src/Codec/Picture/Bitmap.hs
@@ -384,8 +384,8 @@ encodeBitmapWithPalette pal@(BmpPalette palette) img =
 
           paletteSize = fromIntegral $ length palette
           bpp = bitsPerPixel (undefined :: pixel)
-          padding = linePadding bpp (imgWidth + 1)
-          imagePixelSize = fromIntegral $ (imgWidth + padding) * imgHeight * 4
+          padding = linePadding bpp imgWidth
+          imagePixelSize = fromIntegral $ (imgWidth * div bpp 8 + padding) * imgHeight
           hdr = BmpHeader {
               magicIdentifier = bitmapMagicIdentifier,
               fileSize = sizeofBmpHeader + sizeofBmpInfo + 4 * paletteSize + imagePixelSize,


### PR DESCRIPTION
The stated size of bitmaps with RGB8 (3-byte) pixels was incorrect, as identified by ImageMagick:

```
$ identify juicy.bmp
juicy.bmp BMP 256x256 256x256+0+0 8-bit sRGB 197KB 0.000u 0:00.000
identify: length and filesize do not match `juicy.bmp' @ error/bmp.c/ReadBMPImage/822.
```

The padding size (which is only present with non-RGBA8 pixels) appears to have been factored in incorrectly.

I used this to verify that the sizes of all images up to 40x40 with all possible BMP pixel types now have the correct size calculated:

```haskell
module Main where

import Codec.Picture
import qualified Data.ByteString as B
import Control.Monad (forM_, when)

main :: IO ()
main = forM_ [ (w, h) | w <- [0..40], h <- [0..40] ] $ \(w, h) -> do
  let f px = do
        writeBitmap "out.bmp" $ generateImage (\_ _ -> px) w h
        bs <- B.readFile "out.bmp"
        let [a,b,c,d] = map (B.index bs) [2,3,4,5]
            fi = fromIntegral
            len = fi a + 0x100 * fi b + 0x10000 * fi c + 0x1000000 * fi d
        when (len /= B.length bs) $ error $ show (px, w, h, len, B.length bs)
  f (0 :: Pixel8)
  f $ PixelRGB8 0 0 0
  f $ PixelRGBA8 0 0 0 0
```