### PR TITLE
Bump zlib upper version bounds

### DIFF
--- a/JuicyPixels.cabal
+++ b/JuicyPixels.cabal
@@ -91,7 +91,7 @@ Library
                  bytestring          >= 0.9     && < 0.11,
                  mtl                 >= 1.1     && < 2.3,
                  binary              >= 0.5     && < 0.8,
-                 zlib                >= 0.5.3.1 && < 0.6,
+                 zlib                >= 0.5.3.1 && < 0.7,
                  transformers        >= 0.2,
                  vector              >= 0.9     && < 0.11,
                  primitive           >= 0.4     && < 0.7,


### PR DESCRIPTION
Allow `JuicyPixels` to build with the latest version of `zlib`.