### PR TITLE
make "cabal test" run testSuite instead of benchMark

### DIFF
--- a/JuicyPixels.cabal
+++ b/JuicyPixels.cabal
@@ -70,6 +70,30 @@ Test-suite imageTest
     Build-depends: mmap
     CC-Options: "-DWITH_MMAP_BYTESTRING"
 
+Benchmark imageBenchmark
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test-src
+  Default-Language: Haskell2010
+  Main-Is: main.hs
+  Ghc-options: -O3 -Wall
+  Ghc-prof-options: -rtsopts -Wall -prof -auto-all
+  -- -O3 -Wall
+  --
+  -- -ddump-simpl
+  --
+  Include-Dirs: src/Codec/Picture
+  -- -cpp -prof -auto-all -rtsopts -caf-all -fforce-recomp
+  Build-depends: base,
+                 bytestring, mtl, binary, zlib, transformers,
+                 vector, primitive, deepseq,
+                 filepath            >= 1.3,
+                 criterion           >= 1.0,
+                 JuicyPixels
+
+  if flag(Mmap)
+    Build-depends: mmap
+    CC-Options: "-DWITH_MMAP_BYTESTRING"
+
 Library
   hs-source-dirs: src
   Default-Language: Haskell2010

--- a/test-src/main.hs
+++ b/test-src/main.hs
@@ -9,9 +9,11 @@ import Codec.Picture.Tiff
 import System.Environment
 
 import Data.Binary
+import Data.Char( toLower )
+import Data.List( isInfixOf )
 import Data.Monoid
 import Data.Word( Word8 )
-import Control.Monad( forM_ )
+import Control.Monad( forM_, liftM )
 import System.FilePath
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
@@ -590,6 +592,7 @@ debug = do
 
 myMain :: IO ()
 myMain = do
+    prog <- liftM (map toLower) getProgName
     args <- getArgs
     case args of
         ("test":_) -> testSuite
@@ -597,6 +600,8 @@ myMain = do
         ("jpegtopng":_) -> jpegToPng
         ("pngtojpeg":_) -> pngToJpeg
         ("pngtobmp":_) -> pngToBmp
+        [] | "imagetest"      `isInfixOf` prog -> testSuite
+           | "imagebenchmark" `isInfixOf` prog -> benchMark
         _ -> do
             putStrLn ("Unknown command " ++ show args ++ "Launching benchMark")
             benchMark


### PR DESCRIPTION
I noticed that "cabal test" actually runs the benchmark, not the test suite:

```
WhiteAndNerdy:Juicy.Pixels ppelleti$ cabal test --show-details=always
Building JuicyPixels-3.2.4...
Preprocessing library JuicyPixels-3.2.4...
In-place registering JuicyPixels-3.2.4...
Preprocessing executable 'toPng' for JuicyPixels-3.2.4...
Linking dist/build/toPng/toPng ...
Preprocessing test suite 'imageTest' for JuicyPixels-3.2.4...
Linking dist/build/imageTest/imageTest ...
Running 1 test suites...
Test suite imageTest: RUNNING...
Unknown command []Launching benchMark
Benchmarking
benchmarking trad/JPG -> PNG
time                 154.3 ms   (150.3 ms .. 157.8 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 153.0 ms   (150.0 ms .. 155.4 ms)
std dev              3.614 ms   (2.217 ms .. 5.347 ms)
variance introduced by outliers: 12% (moderately inflated)

benchmarking trad/PNG -> JPG
time                 862.1 ms   (829.9 ms .. 935.0 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 859.3 ms   (849.2 ms .. 866.4 ms)
std dev              10.79 ms   (0.0 s .. 12.39 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking trad/GIF -> PNG
time                 631.8 ms   (619.5 ms .. 649.5 ms)
                     1.000 R²   (NaN R² .. 1.000 R²)
mean                 640.6 ms   (636.7 ms .. 643.5 ms)
std dev              4.339 ms   (0.0 s .. 4.958 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking trad/PNG -> BMP
time                 274.8 ms   (239.0 ms .. 313.5 ms)
                     0.995 R²   (0.977 R² .. 1.000 R²)
mean                 319.0 ms   (299.6 ms .. 336.9 ms)
std dev              22.36 ms   (19.15 ms .. 24.09 ms)
variance introduced by outliers: 17% (moderately inflated)

benchmarking reading/Huge jpeg
time                 1.906 s    (1.564 s .. 2.247 s)
                     0.996 R²   (0.984 R² .. 1.000 R²)
mean                 2.123 s    (2.039 s .. 2.205 s)
std dev              140.5 ms   (0.0 s .. 142.2 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking reading/Huge png
time                 309.2 ms   (277.4 ms .. 339.0 ms)
                     0.997 R²   (0.992 R² .. 1.000 R²)
mean                 299.6 ms   (288.9 ms .. 307.1 ms)
std dev              10.83 ms   (4.801 ms .. 15.09 ms)
variance introduced by outliers: 16% (moderately inflated)

benchmarking reading/Huge gif
time                 1.675 s    (1.514 s .. 1.866 s)
                     0.998 R²   (0.995 R² .. 1.000 R²)
mean                 1.697 s    (1.656 s .. 1.721 s)
std dev              36.76 ms   (0.0 s .. 40.91 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking writing/Huge jpeg
time                 9.052 ms   (4.372 ms .. 13.71 ms)
                     0.285 R²   (0.079 R² .. 0.770 R²)
mean                 13.59 ms   (10.96 ms .. 19.84 ms)
std dev              8.375 ms   (3.864 ms .. 12.07 ms)
variance introduced by outliers: 96% (severely inflated)

benchmarking writing/Huge png
time                 202.4 ms   (56.15 ms .. 317.7 ms)
                     0.798 R²   (0.583 R² .. 1.000 R²)
mean                 263.1 ms   (213.4 ms .. 326.9 ms)
std dev              72.57 ms   (38.88 ms .. 101.3 ms)
variance introduced by outliers: 65% (severely inflated)

END
Test suite imageTest: PASS
Test suite logged to: dist/test/JuicyPixels-3.2.4-imageTest.log
1 of 1 test suites (1 of 1 test cases) passed.
```

I've changed it so that "cabal test" runs the test suite instead, and "cabal bench" can be used to run the benchmark.  I'm using the executable name to determine which to run, which is a bit inelegant, so I don't know if a more thorough refactoring is needed.