### PR TITLE
Needs GHC >= 7.4

### DIFF
--- a/JuicyPixels.cabal
+++ b/JuicyPixels.cabal
@@ -113,7 +113,7 @@ Library
 
   Ghc-options: -O3 -Wall
   Ghc-prof-options: -rtsopts -Wall -prof -auto-all
-  Build-depends: base                >= 4       && < 5,
+  Build-depends: base                >= 4.5     && < 5,
                  bytestring          >= 0.9     && < 0.11,
                  mtl                 >= 1.1     && < 2.3,
                  binary              >= 0.5     && < 0.8,


### PR DESCRIPTION
Build matrix: http://matrix.hackage.haskell.org/package/JuicyPixels

I've revised existing versions to make `cabal install JuicyPixels` succeed on GHC < 7.4: http://hackage.haskell.org/package/JuicyPixels/revisions