### PR TITLE
recode Codec/Picture/Jpg/Types.hs to UTF-8

### DIFF
--- a/src/Codec/Picture/Jpg/Types.hs
+++ b/src/Codec/Picture/Jpg/Types.hs
@@ -206,7 +206,7 @@ instance Binary JpgJFIFApp0 where
 
 {-Thumbnail width (tw) 	1 	Horizontal size of embedded JFIF thumbnail in pixels-}
 {-Thumbnail height (th) 	1 	Vertical size of embedded JFIF thumbnail in pixels-}
-{-Thumbnail data 	3 × tw × th 	Uncompressed 24 bit RGB raster thumbnail-}
+{-Thumbnail data 	3 Ã— tw Ã— th 	Uncompressed 24 bit RGB raster thumbnail-}
 
 instance Binary AdobeTransform where
   put v = case v of


### PR DESCRIPTION
A comment used ISO-8859-1 encoding for 'x' sign.
That made HsColour (ran by haddock) upset:
    Preprocessing library JuicyPixels-3.2.5...
    HsColour: src/Codec/Picture/Jpg/Types.hs: hGetContents: invalid argument (invalid byte sequence)

Fixed by converting source to UTF-8.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>