### PR TITLE
Fixing problems with createMutableImage

### DIFF
--- a/src/Codec/Picture/Types.hs
+++ b/src/Codec/Picture/Types.hs
@@ -323,9 +323,9 @@ createMutableImage :: (Pixel px, PrimMonad m)
                    -> Int -- ^ Height
                    -> px  -- ^ Background color
                    -> m (MutableImage (PrimState m) px)
-{-# NOINLINE createMutableImage #-}
+{-# INLINE createMutableImage #-}
 createMutableImage width height background =
-   unsafeThawImage $ generateImage (\_ _ -> background) width height
+   thawImage $ generateImage (\_ _ -> background) width height
 
 -- | Create a mutable image with garbage as content. All data
 -- is uninitialized.


### PR DESCRIPTION
https://github.com/Twinside/Juicy.Pixels/issues/112

I am sorry, I had not tested @Twinside's workaround in yesterday because it was late at night.

Same problem was happend in version 3.2.6.3.

Switch unsafeThawImage to thawImage seems to work properly.