### PR TITLE
JPEG decoding much faster!

### DIFF
--- a/src/Codec/Picture/Jpg/Common.hs
+++ b/src/Codec/Picture/Jpg/Common.hs
@@ -23,11 +23,10 @@ module Codec.Picture.Jpg.Common
 import Control.Applicative( pure, (<$>) )
 #endif
 
-import Control.Monad( replicateM, when )
+import Control.Monad( when )
 import Control.Monad.ST( ST, runST )
 import Data.Bits( unsafeShiftL, unsafeShiftR, (.&.) )
 import Data.Int( Int16, Int32 )
-import Data.List( foldl' )
 import Data.Maybe( fromMaybe )
 import Data.Word( Word8 )
 import qualified Data.Vector.Storable as VS
@@ -174,8 +173,7 @@ zigZagReorder zigzaged block = do
 
 -- | Unpack an int of the given size encoded from MSB to LSB.
 unpackInt :: Int -> BoolReader s Int32
-unpackInt bitCount = packInt <$> replicateM bitCount getNextBitJpg
-
+unpackInt = getNextIntJpg
 
 {-# INLINE rasterMap #-}
 rasterMap :: (Monad m)
@@ -186,11 +184,6 @@ rasterMap width height f = liner 0
         liner y = columner 0
           where columner x | x >= width = liner (y + 1)
                 columner x = f x y >> columner (x + 1)
-
-packInt :: [Bool] -> Int32
-packInt = foldl' bitStep 0
-    where bitStep acc True = (acc `unsafeShiftL` 1) + 1
-          bitStep acc False = acc `unsafeShiftL` 1
 
 pixelClamp :: Int16 -> Word8
 pixelClamp n = fromIntegral . min 255 $ max 0 n


### PR DESCRIPTION
I noticed in some of my image processing code that reading JPEGs with JuicyPixels was actually taking up the vast majority of my time. After profiling it turned out that most of this was spent on the `unpackInt` function.

```
COST CENTRE                             MODULE                         %time %alloc
unpackInt                               Codec.Picture.Jpg.Common        20.1   23.0
```

the previous version of `unpackInt` masked and shifted every single bit in the integer individually, which caused a lot of overhead. This new version, instead of operating on individual bits, works with the bytes in the ByteString, and ends up being a lot faster.

This passes the test cases, and the benchmarks show quite an improvement!

Old version:
```
benchmarking reading/Huge jpeg
time                 4.857 s    (4.810 s .. 4.913 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.884 s    (4.872 s .. 4.896 s)
std dev              19.35 ms   (0.0 s .. 20.08 ms)
variance introduced by outliers: 19% (moderately inflated)
```

New version:
```
benchmarking reading/Huge jpeg
time                 1.922 s    (1.898 s .. 1.948 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.938 s    (1.932 s .. 1.944 s)
std dev              10.28 ms   (0.0 s .. 10.53 ms)
variance introduced by outliers: 19% (moderately inflated)
```
Additionally, instead of my image processing code taking 12 seconds to run, it now only takes 3 seconds. This is manipulating a 5MP image.

Please let me know if you would like to know anything, or like me to change anything. This change has made using JuicyPixels plausible for me, when before it was much too slow! I'd very much like to see this improvement in future versions :).

Cheers!