### PR TITLE
Metadatas:  Semigroup instance (GHC 8.4 compat)

### DIFF
--- a/src/Codec/Picture/Metadata.hs
+++ b/src/Codec/Picture/Metadata.hs
@@ -171,7 +171,12 @@ newtype Metadatas = Metadatas
 
 instance Monoid Metadatas where
   mempty = empty
+#if !MIN_VERSION_base(4,11,0)
   mappend = union
+#else
+instance Semigroup Metadatas where
+  (<>) = union
+#endif
 
 -- | Right based union
 union :: Metadatas -> Metadatas -> Metadatas


### PR DESCRIPTION
Fix #151 -- tested with GHC 8.4.1-alpha1, 8.0.2, 7.10.3.