### PR TITLE
Fix encoding of last GIF bytes

### DIFF
--- a/src/Codec/Picture/Gif/LZWEncoding.hs
+++ b/src/Codec/Picture/Gif/LZWEncoding.hs
@@ -88,7 +88,7 @@ lzwEncode initialKeySize vec = runST $ do
     writeBitsGif bitWriter (fromIntegral clearCode) startCodeSize
     go 0 (startCodeSize, firstFreeIndex, initialTrie)
 
-    finalizeBoolWriter bitWriter
+    finalizeBoolWriterGif bitWriter
   where
     maxi = V.length vec
 


### PR DESCRIPTION
The current GIF data LZW encoding handles the last byte wrong, by placing the left over bits to the top of the last byte. Should stacked in low-to-high order, like the rest already are.