### PR TITLE
Correctly decode the size of a 1-bit local palette

### DIFF
--- a/src/Codec/Picture/Gif.hs
+++ b/src/Codec/Picture/Gif.hs
@@ -399,7 +399,6 @@ instance Binary ImageDescriptor where
         imgWidth   <- getWord16le
         imgHeight  <- getWord16le
         packedFields <- getWord8
-        let tableSize = packedFields .&. 0x7
         return ImageDescriptor
             { gDescPixelsFromLeft = imgLeftPos
             , gDescPixelsFromTop  = imgTopPos
@@ -408,7 +407,7 @@ instance Binary ImageDescriptor where
             , gDescHasLocalMap    = packedFields `testBit` 7
             , gDescIsInterlaced     = packedFields `testBit` 6
             , gDescIsImgDescriptorSorted = packedFields `testBit` 5
-            , gDescLocalColorTableSize = if tableSize > 0 then tableSize + 1 else 0
+            , gDescLocalColorTableSize = (packedFields .&. 0x7) + 1
             }
 
 


### PR DESCRIPTION
The code currently handles reading the size of a 1-bit local palette wrong. It's expressed as 0 in the packed field.