### PR TITLE
API for more control over GIF file details

### DIFF
--- a/src/Codec/Picture/Gif.hs
+++ b/src/Codec/Picture/Gif.hs
@@ -16,14 +16,15 @@ module Codec.Picture.Gif ( -- * Reading
                          , GifEncode( .. )
                          , GifFrame( .. )
                          , GifLooping( .. )
-                         , encodeComplexGifImage
                          , encodeGifImage
                          , encodeGifImageWithPalette
                          , encodeGifImages
+                         , encodeComplexGifImage
 
                          , writeGifImage
                          , writeGifImageWithPalette
                          , writeGifImages
+                         , writeComplexGifImage
                          , greyPalette
                          ) where
 
@@ -1000,3 +1001,5 @@ writeGifImageWithPalette :: FilePath -> Image Pixel8 -> Palette
 writeGifImageWithPalette file img palette =
     L.writeFile file <$> encodeGifImageWithPalette img palette
 
+writeComplexGifImage :: FilePath -> GifEncode -> Either String (IO ())
+writeComplexGifImage file spec = L.writeFile file <$> encodeComplexGifImage spec


### PR DESCRIPTION
These patches add a new way of defining a GIF to be encoded that exposes more of the format's details.

This allows the creation of images like ![sample](https://user-images.githubusercontent.com/1919571/44007083-de07a2b6-9e97-11e8-96ae-4cacb5026ea7.gif) (transparency + disposal method control to show more than 256 colours at once, non-uniform frame dimensions to keep the file size down).

I'm not sure I've got the names right on `encodeComplexGifImage`, `GifEncode` or `GifFrame`. They feel a bit off, but I haven't come up with better yet.