### PR TITLE
Expose internal modules

### DIFF
--- a/JuicyPixels.cabal
+++ b/JuicyPixels.cabal
@@ -112,7 +112,21 @@ Library
                     Codec.Picture.Metadata.Exif,
                     Codec.Picture.Saving,
                     Codec.Picture.Types,
-                    Codec.Picture.ColorQuant
+                    Codec.Picture.ColorQuant,
+                    Codec.Picture.Jpg.Internal.DefaultTable,
+                    Codec.Picture.Jpg.Internal.Metadata,
+                    Codec.Picture.Jpg.Internal.FastIdct,
+                    Codec.Picture.Jpg.Internal.FastDct,
+                    Codec.Picture.Jpg.Internal.Types,
+                    Codec.Picture.Jpg.Internal.Common,
+                    Codec.Picture.Jpg.Internal.Progressive,
+                    Codec.Picture.Gif.Internal.LZW,
+                    Codec.Picture.Gif.Internal.LZWEncoding,
+                    Codec.Picture.Png.Internal.Export,
+                    Codec.Picture.Png.Internal.Type,
+                    Codec.Picture.Png.Internal.Metadata,
+                    Codec.Picture.Tiff.Internal.Metadata,
+                    Codec.Picture.Tiff.Internal.Types
 
   Ghc-options: -O3 -Wall
   Build-depends: base                >= 4.8     && < 6,
@@ -127,21 +141,7 @@ Library
                  containers          >= 0.4.2   && < 0.7
 
   -- Modules not exported by this package.
-  Other-modules: Codec.Picture.Jpg.DefaultTable,
-                 Codec.Picture.Jpg.Metadata,
-                 Codec.Picture.Jpg.FastIdct,
-                 Codec.Picture.Jpg.FastDct,
-                 Codec.Picture.Jpg.Types,
-                 Codec.Picture.Jpg.Common,
-                 Codec.Picture.Jpg.Progressive,
-                 Codec.Picture.Gif.LZW,
-                 Codec.Picture.Gif.LZWEncoding,
-                 Codec.Picture.Png.Export,
-                 Codec.Picture.Png.Type,
-                 Codec.Picture.Png.Metadata,
-                 Codec.Picture.Tiff.Metadata,
-                 Codec.Picture.Tiff.Types,
-                 Codec.Picture.BitWriter,
+  Other-modules: Codec.Picture.BitWriter,
                  Codec.Picture.InternalHelper,
                  Codec.Picture.VectorByteConversion
 

--- a/src/Codec/Picture/Gif.hs
+++ b/src/Codec/Picture/Gif.hs
@@ -69,8 +69,8 @@ import Codec.Picture.Types
 import Codec.Picture.Metadata( Metadatas
                              , SourceFormat( SourceGif )
                              , basicMetadata )
-import Codec.Picture.Gif.LZW
-import Codec.Picture.Gif.LZWEncoding
+import Codec.Picture.Gif.Internal.LZW
+import Codec.Picture.Gif.Internal.LZWEncoding
 import Codec.Picture.BitWriter
 
 -- | Delay to wait before showing the next Gif image.

--- a/src/Codec/Picture/Gif/Internal/LZW.hs
+++ b/src/Codec/Picture/Gif/Internal/LZW.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-module Codec.Picture.Gif.LZW( decodeLzw, decodeLzwTiff ) where
+module Codec.Picture.Gif.Internal.LZW( decodeLzw, decodeLzwTiff ) where
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative( (<$>) )

--- a/src/Codec/Picture/Gif/Internal/LZWEncoding.hs
+++ b/src/Codec/Picture/Gif/Internal/LZWEncoding.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, CPP #-}
-module Codec.Picture.Gif.LZWEncoding( lzwEncode ) where
+module Codec.Picture.Gif.Internal.LZWEncoding( lzwEncode ) where
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative( (<$>) )

--- a/src/Codec/Picture/Jpg.hs
+++ b/src/Codec/Picture/Jpg.hs
@@ -52,14 +52,14 @@ import Codec.Picture.Types
 import Codec.Picture.Metadata( Metadatas
                              , SourceFormat( SourceJpeg )
                              , basicMetadata )
-import Codec.Picture.Tiff.Types
-import Codec.Picture.Tiff.Metadata
-import Codec.Picture.Jpg.Types
-import Codec.Picture.Jpg.Common
-import Codec.Picture.Jpg.Progressive
-import Codec.Picture.Jpg.DefaultTable
-import Codec.Picture.Jpg.FastDct
-import Codec.Picture.Jpg.Metadata
+import Codec.Picture.Tiff.Internal.Types
+import Codec.Picture.Tiff.Internal.Metadata
+import Codec.Picture.Jpg.Internal.Types
+import Codec.Picture.Jpg.Internal.Common
+import Codec.Picture.Jpg.Internal.Progressive
+import Codec.Picture.Jpg.Internal.DefaultTable
+import Codec.Picture.Jpg.Internal.FastDct
+import Codec.Picture.Jpg.Internal.Metadata
 
 quantize :: MacroBlock Int16 -> MutableMacroBlock s Int32
          -> ST s (MutableMacroBlock s Int32)

--- a/src/Codec/Picture/Jpg/Internal/Common.hs
+++ b/src/Codec/Picture/Jpg/Internal/Common.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE CPP #-}
-module Codec.Picture.Jpg.Common
+module Codec.Picture.Jpg.Internal.Common
     ( DctCoefficients
     , JpgUnpackerParameter( .. )
     , decodeInt
@@ -36,9 +36,9 @@ import Foreign.Storable ( Storable )
 
 import Codec.Picture.Types
 import Codec.Picture.BitWriter
-import Codec.Picture.Jpg.Types
-import Codec.Picture.Jpg.FastIdct
-import Codec.Picture.Jpg.DefaultTable
+import Codec.Picture.Jpg.Internal.Types
+import Codec.Picture.Jpg.Internal.FastIdct
+import Codec.Picture.Jpg.Internal.DefaultTable
 
 -- | Same as for DcCoefficient, to provide nicer type signatures
 type DctCoefficients = DcCoefficient

--- a/src/Codec/Picture/Jpg/Internal/DefaultTable.hs
+++ b/src/Codec/Picture/Jpg/Internal/DefaultTable.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 -- | Module used by the jpeg decoder internally, shouldn't be used
 -- in user code.
-module Codec.Picture.Jpg.DefaultTable( DctComponent( .. )
+module Codec.Picture.Jpg.Internal.DefaultTable( DctComponent( .. )
                                      , HuffmanTree( .. )
                                      , HuffmanTable
                                      , HuffmanPackedTree

--- a/src/Codec/Picture/Jpg/Internal/FastDct.hs
+++ b/src/Codec/Picture/Jpg/Internal/FastDct.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies #-}
-module Codec.Picture.Jpg.FastDct( referenceDct, fastDctLibJpeg ) where
+module Codec.Picture.Jpg.Internal.FastDct( referenceDct, fastDctLibJpeg ) where
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative( (<$>) )
@@ -12,7 +12,7 @@ import Control.Monad.ST( ST )
 
 import qualified Data.Vector.Storable.Mutable as M
 
-import Codec.Picture.Jpg.Types
+import Codec.Picture.Jpg.Internal.Types
 import Control.Monad( forM, forM_ )
 
 -- | Reference implementation of the DCT, directly implementing the formula

--- a/src/Codec/Picture/Jpg/Internal/FastIdct.hs
+++ b/src/Codec/Picture/Jpg/Internal/FastIdct.hs
@@ -13,7 +13,7 @@
 --
 -- this code assumes >> to be a two's-complement arithmetic
 -- right shift: (-2)>>1 == -1 , (-3)>>1 == -2               
-module Codec.Picture.Jpg.FastIdct( MutableMacroBlock
+module Codec.Picture.Jpg.Internal.FastIdct( MutableMacroBlock
                                  , fastIdct
                                  , mutableLevelShift
                                  , createEmptyMutableMacroBlock
@@ -25,7 +25,7 @@ import Data.Bits( unsafeShiftL, unsafeShiftR )
 import Data.Int( Int16 )
 import qualified Data.Vector.Storable.Mutable as M
 
-import Codec.Picture.Jpg.Types
+import Codec.Picture.Jpg.Internal.Types
 
 iclip :: V.Vector Int16
 iclip = V.fromListN 1024 [ val i| i <- [(-512) .. 511] ]

--- a/src/Codec/Picture/Jpg/Internal/Metadata.hs
+++ b/src/Codec/Picture/Jpg/Internal/Metadata.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-module Codec.Picture.Jpg.Metadata ( extractMetadatas, encodeMetadatas ) where
+module Codec.Picture.Jpg.Internal.Metadata ( extractMetadatas, encodeMetadatas ) where
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative( pure )
@@ -11,7 +11,7 @@ import Data.Word( Word16 )
 import Data.Maybe( fromMaybe )
 import qualified Codec.Picture.Metadata as Met
 import Codec.Picture.Metadata( Metadatas )
-import Codec.Picture.Jpg.Types
+import Codec.Picture.Jpg.Internal.Types
 
 scalerOfUnit :: JFifUnit -> Met.Keys Word -> Word16 -> Metadatas -> Metadatas
 scalerOfUnit unit k v = case unit of

--- a/src/Codec/Picture/Jpg/Internal/Progressive.hs
+++ b/src/Codec/Picture/Jpg/Internal/Progressive.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE CPP #-}
-module Codec.Picture.Jpg.Progressive
+module Codec.Picture.Jpg.Internal.Progressive
     ( JpgUnpackerParameter( .. )
     , progressiveUnpack
     ) where
@@ -27,9 +27,9 @@ import qualified Data.Vector.Storable.Mutable as MS
 
 import Codec.Picture.Types
 import Codec.Picture.BitWriter
-import Codec.Picture.Jpg.Common
-import Codec.Picture.Jpg.Types
-import Codec.Picture.Jpg.DefaultTable
+import Codec.Picture.Jpg.Internal.Common
+import Codec.Picture.Jpg.Internal.Types
+import Codec.Picture.Jpg.Internal.DefaultTable
 
 createMcuLineIndices :: JpgComponent -> Int -> Int -> V.Vector (VS.Vector Int)
 createMcuLineIndices param imgWidth mcuWidth =

--- a/src/Codec/Picture/Jpg/Internal/Types.hs
+++ b/src/Codec/Picture/Jpg/Internal/Types.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE CPP #-}
-module Codec.Picture.Jpg.Types( MutableMacroBlock
+module Codec.Picture.Jpg.Internal.Types( MutableMacroBlock
                               , createEmptyMutableMacroBlock
                               , printMacroBlock
                               , printPureMacroBlock
@@ -66,9 +66,9 @@ import Data.Binary.Put( Put
                       )
 
 import Codec.Picture.InternalHelper
-import Codec.Picture.Jpg.DefaultTable
-import Codec.Picture.Tiff.Types
-import Codec.Picture.Tiff.Metadata( exifOffsetIfd )
+import Codec.Picture.Jpg.Internal.DefaultTable
+import Codec.Picture.Tiff.Internal.Types
+import Codec.Picture.Tiff.Internal.Metadata( exifOffsetIfd )
 import Codec.Picture.Metadata.Exif
 
 {-import Debug.Trace-}

--- a/src/Codec/Picture/Png.hs
+++ b/src/Codec/Picture/Png.hs
@@ -52,9 +52,9 @@ import Foreign.Storable ( Storable )
 
 import Codec.Picture.Types
 import Codec.Picture.Metadata
-import Codec.Picture.Png.Type
-import Codec.Picture.Png.Export
-import Codec.Picture.Png.Metadata
+import Codec.Picture.Png.Internal.Type
+import Codec.Picture.Png.Internal.Export
+import Codec.Picture.Png.Internal.Metadata
 import Codec.Picture.InternalHelper
 
 -- | Simple structure used to hold information about Adam7 deinterlacing.

--- a/src/Codec/Picture/Png/Internal/Export.hs
+++ b/src/Codec/Picture/Png/Internal/Export.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 -- | Module implementing a basic png export, no filtering is applyed, but
 -- export at least valid images.
-module Codec.Picture.Png.Export( PngSavable( .. )
+module Codec.Picture.Png.Internal.Export( PngSavable( .. )
                                , PngPaletteSaveable( .. )
                                , writePng
                                , encodeDynamicPng
@@ -29,8 +29,8 @@ import qualified Data.Vector.Storable as VS
 import qualified Data.Vector.Storable.Mutable as M
 
 import Codec.Picture.Types
-import Codec.Picture.Png.Type
-import Codec.Picture.Png.Metadata
+import Codec.Picture.Png.Internal.Type
+import Codec.Picture.Png.Internal.Metadata
 import Codec.Picture.Metadata( Metadatas )
 import Codec.Picture.VectorByteConversion( blitVector, toByteString )
 

--- a/src/Codec/Picture/Png/Internal/Metadata.hs
+++ b/src/Codec/Picture/Png/Internal/Metadata.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Codec.Picture.Png.Metadata( extractMetadatas
+module Codec.Picture.Png.Internal.Metadata( extractMetadatas
                                  , encodeMetadatas
                                  ) where
 
@@ -23,7 +23,7 @@ import qualified Codec.Picture.Metadata as Met
 import Codec.Picture.Metadata ( Metadatas
                               , dotsPerMeterToDotPerInch
                               , Elem( (:=>) ) )
-import Codec.Picture.Png.Type
+import Codec.Picture.Png.Internal.Type
 
 #if !MIN_VERSION_base(4,7,0)
 eitherFoldMap :: Monoid m => (a -> m) -> Either e a -> m

--- a/src/Codec/Picture/Png/Internal/Type.hs
+++ b/src/Codec/Picture/Png/Internal/Type.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
--- | Low level png module, you should import 'Codec.Picture.Png' instead.
-module Codec.Picture.Png.Type( PngIHdr( .. )
+-- | Low level png module, you should import 'Codec.Picture.Png.Internal' instead.
+module Codec.Picture.Png.Internal.Type( PngIHdr( .. )
                              , PngFilter( .. )
                              , PngInterlaceMethod( .. )
                              , PngPalette

--- a/src/Codec/Picture/Saving.hs
+++ b/src/Codec/Picture/Saving.hs
@@ -120,7 +120,7 @@ imageToRadiance (ImageRGBA16 img) =
 -- of 'decodeImage' for jpeg encoding
 -- Save Y or YCbCr Jpeg only, all other colorspaces are converted.
 -- To save a RGB or CMYK JPEG file, use the
--- 'Codec.Picture.Jpg.encodeDirectJpegAtQualityWithMetadata' function
+-- 'Codec.Picture.Jpg.Internal.encodeDirectJpegAtQualityWithMetadata' function
 imageToJpg :: Int -> DynamicImage -> L.ByteString
 imageToJpg quality dynImage =
     let encodeAtQuality = encodeJpegAtQuality (fromIntegral quality)

--- a/src/Codec/Picture/Tiff.hs
+++ b/src/Codec/Picture/Tiff.hs
@@ -63,9 +63,9 @@ import Codec.Picture.Metadata( Metadatas )
 import Codec.Picture.InternalHelper
 import Codec.Picture.BitWriter
 import Codec.Picture.Types
-import Codec.Picture.Gif.LZW
-import Codec.Picture.Tiff.Types
-import Codec.Picture.Tiff.Metadata
+import Codec.Picture.Gif.Internal.LZW
+import Codec.Picture.Tiff.Internal.Types
+import Codec.Picture.Tiff.Internal.Metadata
 import Codec.Picture.VectorByteConversion( toByteString )
 
 data TiffInfo = TiffInfo

--- a/src/Codec/Picture/Tiff/Internal/Metadata.hs
+++ b/src/Codec/Picture/Tiff/Internal/Metadata.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-module Codec.Picture.Tiff.Metadata
+module Codec.Picture.Tiff.Internal.Metadata
     ( extractTiffMetadata
     , encodeTiffStringMetadata
     , exifOffsetIfd
@@ -22,7 +22,7 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
 import qualified Codec.Picture.Metadata as Met
 import qualified Data.Vector.Generic as V
-import Codec.Picture.Tiff.Types
+import Codec.Picture.Tiff.Internal.Types
 import Codec.Picture.Metadata( extractExifMetas )
 import Codec.Picture.Metadata.Exif
 

--- a/src/Codec/Picture/Tiff/Internal/Types.hs
+++ b/src/Codec/Picture/Tiff/Internal/Types.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
-module Codec.Picture.Tiff.Types
+module Codec.Picture.Tiff.Internal.Types
     ( BinaryParam( .. )
     , Endianness( .. )
     , TiffHeader( .. )

--- a/test-src/main.hs
+++ b/test-src/main.hs
@@ -4,12 +4,12 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 import Codec.Picture
-import Codec.Picture.Jpg( JpgEncodable 
+import Codec.Picture.Jpg.Internal( JpgEncodable 
                         , decodeJpegWithMetadata
                         , encodeJpeg
                         , encodeDirectJpegAtQualityWithMetadata )
-import Codec.Picture.Gif
-import Codec.Picture.Tiff
+import Codec.Picture.Gif.Internal
+import Codec.Picture.Tiff.Internal
 import System.Environment
 
 import Data.Binary
@@ -26,7 +26,7 @@ import Codec.Picture.Types
 import Codec.Picture.Saving
 import Codec.Picture.HDR
 import Codec.Picture.Bitmap( encodeBitmapWithMetadata )
-import Codec.Picture.Png( encodePalettedPngWithMetadata )
+import Codec.Picture.Png.Internal( encodePalettedPngWithMetadata )
 import qualified Codec.Picture.Metadata as Met
 import qualified Codec.Picture.Metadata.Exif as Met
 import qualified Data.Vector.Storable as V

--- a/tests/Juicy.hs
+++ b/tests/Juicy.hs
@@ -13,11 +13,11 @@ import qualified Data.Vector.Storable.Mutable as M
 import Text.Printf
 import Debug.Trace
 
-import Codec.Picture.Jpg.FastIdct
-import Codec.Picture.Jpg.DefaultTable
+import Codec.Picture.Jpg.Internal.FastIdct
+import Codec.Picture.Jpg.Internal.DefaultTable
 import Codec.Picture.BitWriter
 import qualified Data.ByteString as B
-import Codec.Picture.Jpg.Types
+import Codec.Picture.Jpg.Internal.Types
 
 {-testBoolWriter :: (forall s. BoolWriter s b) -> [Word8]-}
 {-testBoolWriter = B.unpack . runST . runBoolWriter-}


### PR DESCRIPTION
Renames internal modules and exposes them. Re. https://github.com/Twinside/Juicy.Pixels/issues/161