### PR TITLE
Complete coverage of the bmpsuite 'good' image set

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ Status
         * in a gAMA field : 'Gamma'
         * DPI information in a pHYs chunk.
 
- - Bitmap (.bmp) (mainly used as a debug output format)
+ - Bitmap (.bmp)
     * Reading
-        - 32bits (RGBA) images
-        - 24bits (RGB) images
-        - 1,4,8 bits (greyscale & paletted) images
+        - 16 or 32 bit RGBA images
+        - 16, 24, 32 bit RGB images
+        - 1, 4, or 8 bit (greyscale & paletted) images
         - RLE encoded or uncompressed
+        - Windows 2.0/3.1/95/98 style bitmaps all supported
 
     * Writing
         - 32bits (RGBA) per pixel images

--- a/src/Codec/Picture/Png/Internal/Metadata.hs
+++ b/src/Codec/Picture/Png/Internal/Metadata.hs
@@ -116,6 +116,7 @@ encodeSingleMetadata = Met.foldMap go where
     Met.Format :=> _ -> mempty
     Met.Gamma       :=> g ->
       pure $ mkRawChunk gammaSignature . encode $ PngGamma g
+    Met.ColorSpace  :=> _ -> mempty
     Met.Title       :=> tx -> txt "Title" (L.pack tx)
     Met.Description :=> tx -> txt "Description" (L.pack tx)
     Met.Author      :=> tx -> txt "Author" (L.pack tx)

--- a/test-src/main.hs
+++ b/test-src/main.hs
@@ -4,12 +4,12 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 import Codec.Picture
-import Codec.Picture.Jpg.Internal( JpgEncodable 
+import Codec.Picture.Jpg( JpgEncodable 
                         , decodeJpegWithMetadata
                         , encodeJpeg
                         , encodeDirectJpegAtQualityWithMetadata )
-import Codec.Picture.Gif.Internal
-import Codec.Picture.Tiff.Internal
+import Codec.Picture.Gif
+import Codec.Picture.Tiff
 import System.Environment
 
 import Data.Binary
@@ -26,7 +26,7 @@ import Codec.Picture.Types
 import Codec.Picture.Saving
 import Codec.Picture.HDR
 import Codec.Picture.Bitmap( encodeBitmapWithMetadata )
-import Codec.Picture.Png.Internal( encodePalettedPngWithMetadata )
+import Codec.Picture.Png( encodePalettedPngWithMetadata )
 import qualified Codec.Picture.Metadata as Met
 import qualified Codec.Picture.Metadata.Exif as Met
 import qualified Data.Vector.Storable as V


### PR DESCRIPTION
This pull request fills in all of the gaps in our coverage of the bmpsuite 'good' set.  It adds the following bitmap formats:

 * 16 bit RGB with or without bitfields.
 * 16 bit RGBA (with bitfields).
 * Windows 2.0/ OS/2 BITMAPCOREHEADER support.
 * V4 (Windows 95) and V5 (Windows 98) bitmap headers.

It also fixes several bugs regarding 32 bit bitmaps with and without alpha.

The V4 and V5 bitmap headers include colour space information which I have exposed as metadata.

This metadata is also available from other formats such as PNG and JPEG.  The parsers for those formats should be extended to export colour space information.  I see this as a first step to integrating colour management with JuicyPixels.