### PR TITLE
base 4.13 compatibility

### DIFF
--- a/src/Codec/Picture/Bitmap.hs
+++ b/src/Codec/Picture/Bitmap.hs
@@ -884,7 +884,11 @@ decodeBitmapWithHeaders fileHdr hdr = do
       a          -> fail $ "Can't handle BMP file " ++ show a
 
 -- | Decode a bitfield. Will fail if the bitfield is empty.
+#if MIN_VERSION_base(4,13,0)
+getBitfield :: (FiniteBits t, Integral t, Num t, MonadFail m) => t -> m (Bitfield t)
+#else
 getBitfield :: (FiniteBits t, Integral t, Num t, Monad m) => t -> m (Bitfield t)
+#endif
 getBitfield 0 = fail $
   "Codec.Picture.Bitmap.getBitfield: bitfield cannot be 0"
 getBitfield w = return (makeBitfield w)

--- a/src/Codec/Picture/Jpg.hs
+++ b/src/Codec/Picture/Jpg.hs
@@ -309,7 +309,7 @@ jpgMachineStep (JpgScanBlob hdr raw_data) = do
         scanSpecifier scanCount scanSpec = do
             compMapping <- gets componentIndexMapping
             comp <- case lookup (componentSelector scanSpec) compMapping of
-                Nothing -> fail "Jpg decoding error - bad component selector in blob."
+                Nothing -> error "Jpg decoding error - bad component selector in blob."
                 Just v -> return v
             let maximumHuffmanTable = 4
                 dcIndex = min (maximumHuffmanTable - 1) 
@@ -326,7 +326,7 @@ jpgMachineStep (JpgScanBlob hdr raw_data) = do
             frameInfo <- gets currentFrame
             blobId <- gets seenBlobs                   
             case frameInfo of
-              Nothing -> fail "Jpg decoding error - no previous frame"
+              Nothing -> error "Jpg decoding error - no previous frame"
               Just v -> do
                  let compDesc = jpgComponents v !! comp
                      compCount = length $ jpgComponents v


### PR DESCRIPTION
Base 4.13 finally removes `fail` from `Monad`.

This patch adds the now necessary `MonadFail` constraint to `getBitfield` on 4.13+, and switches two calls to `fail` on `Identity` to `error` as `Identity` deliberately does not have a `MonadFail` instance.