### PR TITLE
Warning cleanup

### DIFF
--- a/src/Codec/Picture/ColorQuant.hs
+++ b/src/Codec/Picture/ColorQuant.hs
@@ -120,7 +120,7 @@ uniformQuantization opts img
     (bg, br, bb) = bitDiv3 maxCols
     (dr, dg, db) = (2^(8-br), 2^(8-bg), 2^(8-bb))
     paletteIndex (PixelRGB8 r g b) = fromIntegral $ fromMaybe 0 (elemIndex
-      (PixelRGB8 (r .&. (256 - dr)) (g .&. (256 - dg)) (b .&. (256 - db)))
+      (PixelRGB8 (r .&. negate dr) (g .&. negate dg) (b .&. negate db))
       paletteList)
 
 isColorCountBelow :: Int -> Image PixelRGB8 -> (Set.Set PixelRGB8, Bool)

--- a/src/Codec/Picture/HDR.hs
+++ b/src/Codec/Picture/HDR.hs
@@ -19,7 +19,11 @@ import Control.Applicative( pure, (<*>), (<$>) )
 import Data.Bits( Bits, (.&.), (.|.), unsafeShiftL, unsafeShiftR )
 import Data.Char( ord, chr, isDigit )
 import Data.Word( Word8 )
+
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid( (<>) )
+#endif
+
 import Control.Monad( when, foldM, foldM_, forM, forM_, unless )
 import Control.Monad.Trans.Class( lift )
 import qualified Data.ByteString as B

--- a/src/Codec/Picture/Jpg.hs
+++ b/src/Codec/Picture/Jpg.hs
@@ -31,7 +31,9 @@ import Control.Monad.Trans( lift )
 import Control.Monad.Trans.RWS.Strict( RWS, modify, tell, gets, execRWS )
 
 import Data.Bits( (.|.), unsafeShiftL )
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid( (<>) )
+#endif
 import Data.Int( Int16, Int32 )
 import Data.Word(Word8, Word32)
 import Data.Binary( Binary(..), encode )

--- a/src/Codec/Picture/Jpg/Internal/Types.hs
+++ b/src/Codec/Picture/Jpg/Internal/Types.hs
@@ -34,7 +34,11 @@ import Control.Monad( when, replicateM, forM, forM_, unless )
 import Control.Monad.ST( ST )
 import Data.Bits( (.|.), (.&.), unsafeShiftL, unsafeShiftR )
 import Data.List( partition )
+
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid( (<>) )
+#endif
+
 import Foreign.Storable ( Storable )
 import Data.Vector.Unboxed( (!) )
 import qualified Data.Vector as V

--- a/src/Codec/Picture/Png.hs
+++ b/src/Codec/Picture/Png.hs
@@ -36,7 +36,11 @@ import Control.Applicative( (<$>) )
 import Control.Arrow( first )
 import Control.Monad( forM_, foldM_, when, void )
 import Control.Monad.ST( ST, runST )
+
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid( (<>) )
+#endif
+
 import Data.Binary( Binary( get) )
 
 import qualified Data.Vector.Storable as V

--- a/src/Codec/Picture/Png/Internal/Export.hs
+++ b/src/Codec/Picture/Png/Internal/Export.hs
@@ -19,7 +19,9 @@ import Control.Monad( forM_ )
 import Control.Monad.ST( ST, runST )
 import Data.Bits( unsafeShiftR, (.&.) )
 import Data.Binary( encode )
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid( (<>) )
+#endif
 import Data.Word(Word8, Word16)
 import qualified Codec.Compression.Zlib as Z
 import qualified Data.ByteString as B

--- a/src/Codec/Picture/Png/Internal/Metadata.hs
+++ b/src/Codec/Picture/Png/Internal/Metadata.hs
@@ -16,7 +16,9 @@ import Data.Binary( Binary( get, put ), encode )
 import Data.Binary.Get( getLazyByteStringNul )
 import Data.Binary.Put( putLazyByteString, putWord8 )
 import qualified Data.ByteString.Lazy.Char8 as L
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid( (<>) )
+#endif
 
 import Codec.Picture.InternalHelper
 import qualified Codec.Picture.Metadata as Met

--- a/src/Codec/Picture/Tiff/Internal/Metadata.hs
+++ b/src/Codec/Picture/Tiff/Internal/Metadata.hs
@@ -16,7 +16,9 @@ import Data.Foldable( find )
 import Data.List( sortBy )
 import Data.Function( on )
 import qualified Data.Foldable as F
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid( (<>) )
+#endif
 import Codec.Picture.Metadata( Metadatas )
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC

--- a/src/Codec/Picture/Types.hs
+++ b/src/Codec/Picture/Types.hs
@@ -109,8 +109,9 @@ module Codec.Picture.Types( -- * Types
 import Data.Monoid( Monoid, mempty )
 import Control.Applicative( Applicative, pure, (<*>), (<$>) )
 #endif
-
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid( (<>) )
+#endif
 import Control.Monad( foldM, liftM, ap )
 import Control.DeepSeq( NFData( .. ) )
 import Control.Monad.ST( ST, runST )


### PR DESCRIPTION
Two patches are included:

1. The first uses (<>) from the Prelude on base >= 4.11 to avoid redundant import warnings. 

2. The second fixes a site where you used 256 as a Word8 literal, which triggers warnings on recent GHCs.

With this the package should build warning-free.