### PR TITLE
Fix RGB to CMYK conversion

### DIFF
--- a/src/Codec/Picture/Types.hs
+++ b/src/Codec/Picture/Types.hs
@@ -2256,26 +2256,25 @@ instance ColorSpaceConvertible PixelYCbCrK8 PixelCMYK8 where
                                  -> (Word8, Word8, Word8) -> b #-}
 {-# SPECIALIZE integralRGBToCMYK :: (Word16 -> Word16 -> Word16 -> Word16 -> b)
                                  -> (Word16, Word16, Word16) -> b #-}
+-- | Convert RGB8 or RGB16 to CMYK8 and CMYK16 respectfully.
+--
+-- /Note/ - 32bit precision is not supported. Make sure to adjust implementation if ever
+-- used with Word32.
 integralRGBToCMYK :: (Bounded a, Integral a)
                   => (a -> a -> a -> a -> b)    -- ^ Pixel building function
                   -> (a, a, a)                  -- ^ RGB sample
                   -> b                          -- ^ Resulting sample
-integralRGBToCMYK build (r, g, b) =
-  build (clamp c) (clamp m) (clamp y) (fromIntegral kInt)
-    where maxi = maxBound
-
-          ir = fromIntegral $ maxi - r :: Int
-          ig = fromIntegral $ maxi - g
-          ib = fromIntegral $ maxi - b
-
-          kInt = minimum [ir, ig, ib]
-          ik = fromIntegral maxi - kInt
-
-          c = (ir - kInt) `div` ik
-          m = (ig - kInt) `div` ik
-          y = (ib - kInt) `div` ik
-
-          clamp = fromIntegral . max 0
+integralRGBToCMYK build (r, g, b)
+  | kMax == 0 = build 0 0 0 maxVal -- prevent division by zero
+  | otherwise = build (fromIntegral c) (fromIntegral m) (fromIntegral y) k
+    where maxVal = maxBound
+          max32 = fromIntegral maxVal :: Word32
+          kMax32 = fromIntegral kMax :: Word32
+          kMax = max r (max g b)
+          k = maxVal - kMax
+          c = max32 * (kMax32 - fromIntegral r) `div` kMax32
+          m = max32 * (kMax32 - fromIntegral g) `div` kMax32
+          y = max32 * (kMax32 - fromIntegral b) `div` kMax32
 
 instance ColorSpaceConvertible PixelRGB8 PixelCMYK8 where
   convertPixel (PixelRGB8 r g b) = integralRGBToCMYK PixelCMYK8 (r, g, b)


### PR DESCRIPTION
The usual formula and current implementation of the conversion function forget about the fact that the CMYK channels are represented as a percentage [0..100%] (or as a ratio [0.0 .. 1.0] in case of floating point values), but the CMYK8 and CMYK16 pixels expect those value to be in [0..255] and [0..65535] ranges respectfully.

Fixes #179 