### PR TITLE
Addition of `paletteSize`, while removing private field of `Palette'`

### DIFF
--- a/JuicyPixels.cabal
+++ b/JuicyPixels.cabal
@@ -1,5 +1,5 @@
 Name:                JuicyPixels
-Version:             3.3.4
+Version:             3.3.5
 Synopsis:            Picture loading/serialization (in png, jpeg, bitmap, gif, tga, tiff and radiance)
 Description:
     <<data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAADABAMAAACg8nE0AAAAElBMVEUAAABJqDSTWEL/qyb///8AAABH/1GTAAAAAXRSTlMAQObYZgAAAN5JREFUeF7s1sEJgFAQxFBbsAV72v5bEVYWPwT/XDxmCsi7zvHXavYREBDI3XP2GgICqBBYuwIC+/rVayPUAyAg0HvIXBcQoDFDGnUBgWQQ2Bx3AYFaRoBpAQHWb3bt2ARgGAiCYFFuwf3X5HA/McgGJWI2FdykCv4aBYzmKwDwvl6NVmUAAK2vlwEALK7fo88GANB6HQsAAAAAAAAA7P94AQCzswEAAAAAAAAAAAAAAAAAAICzh4UAO4zWAYBfRutHA4Bn5C69JhowAMGoBaMWDG0wCkbBKBgFo2AUAACPmegUST/IJAAAAABJRU5ErkJggg==>>

--- a/changelog
+++ b/changelog
@@ -1,6 +1,11 @@
 Change log
 ==========
 
+v3.3.5 January 2020
+---------------------
+
+* Addition of `paletteSize`, while removing private field of `Palette'`
+
 v3.3.4 September 2019
 ---------------------
 

--- a/src/Codec/Picture/Bitmap.hs
+++ b/src/Codec/Picture/Bitmap.hs
@@ -867,8 +867,7 @@ decodeBitmapWithHeaders fileHdr hdr = do
                     else replicateM paletteColorCount pixel4Get
         rest <- getData
         let palette = Palette'
-              { _paletteSize = paletteColorCount
-              , _paletteData = VS.fromListN (paletteColorCount * 3) $ concat table
+              { _paletteData = VS.fromListN (paletteColorCount * 3) $ concat table
               }
         image <-
           case (bpp, compression) of
@@ -987,14 +986,14 @@ encodeBitmapWithPaletteAndMetadata metas pal@(BmpPalette palette) img =
                      | colorType == CalibratedRGB || hasAlpha img  = sizeofBmpV4Header
                      | otherwise                                   = sizeofBmpInfoHeader
 
-          paletteSize = fromIntegral $ length palette
+          paletteSize' = fromIntegral $ length palette
           bpp = bitsPerPixel (undefined :: pixel)
 
           profileSize = fromIntegral $ maybe 0 B.length colorProfileData
           imagePixelSize = fromIntegral $ sizeofPixelData bpp imgWidth imgHeight
-          offsetToData = sizeofBmpHeader + headerSize + 4 * paletteSize
+          offsetToData = sizeofBmpHeader + headerSize + 4 * paletteSize'
           offsetToICCProfile = offsetToData + imagePixelSize <$ colorProfileData
-          sizeOfFile = sizeofBmpHeader + headerSize + 4 * paletteSize
+          sizeOfFile = sizeofBmpHeader + headerSize + 4 * paletteSize'
                         + imagePixelSize + profileSize
 
           hdr = BmpHeader {
@@ -1015,7 +1014,7 @@ encodeBitmapWithPaletteAndMetadata metas pal@(BmpPalette palette) img =
               byteImageSize = imagePixelSize,
               xResolution = fromIntegral dpiX,
               yResolution = fromIntegral dpiY,
-              colorCount = paletteSize,
+              colorCount = paletteSize',
               importantColours = 0,
               redMask   = if hasAlpha img then 0x00FF0000 else 0,
               greenMask = if hasAlpha img then 0x0000FF00 else 0,

--- a/src/Codec/Picture/Gif.hs
+++ b/src/Codec/Picture/Gif.hs
@@ -628,8 +628,7 @@ decodeAllGifImages GifFile { gifHeader = GifHeader { gifGlobalMap = palette
             (thisPalette, firstControl, substituteColors thisPalette baseImage)
           scanner = gifAnimationApplyer (globalWidth, globalHeight) thisPalette backImage
           palette' = Palette'
-            { _paletteSize = imageWidth thisPalette
-            , _paletteData = imageData thisPalette
+            { _paletteData = imageData thisPalette
             }
       in
       PalettedRGB8 baseImage palette' :

--- a/src/Codec/Picture/Png.hs
+++ b/src/Codec/Picture/Png.hs
@@ -395,8 +395,8 @@ deinterlacer (PngIHdr { width = w, height = h, colourType  = imgKind
         Right <$> V.unsafeFreeze imgArray
 
 generateGreyscalePalette :: Word8 -> PngPalette
-generateGreyscalePalette bits = Palette' (maxValue+1) vec
-    where maxValue = 2 ^ bits - 1
+generateGreyscalePalette bits = Palette' vec
+    where maxValue = (2 :: Int) ^ bits - 1
           vec = V.fromListN ((fromIntegral maxValue + 1) * 3) $ concat pixels
           pixels = [[i, i, i] | n <- [0 .. maxValue]
                               , let i = fromIntegral $ n * (255 `div` maxValue)]
@@ -415,7 +415,7 @@ paletteRGB4 = generateGreyscalePalette 4
 
 addTransparencyToPalette :: PngPalette -> Lb.ByteString -> Palette' PixelRGBA8
 addTransparencyToPalette pal transpBuffer = 
-  Palette' (_paletteSize pal) . imageData . pixelMapXY addOpacity $ palettedAsImage pal
+  Palette' . imageData . pixelMapXY addOpacity $ palettedAsImage pal
   where 
     maxi = fromIntegral $ Lb.length transpBuffer
     addOpacity ix _ (PixelRGB8 r g b) | ix < maxi =

--- a/src/Codec/Picture/Png/Internal/Type.hs
+++ b/src/Codec/Picture/Png/Internal/Type.hs
@@ -176,10 +176,10 @@ type PngPalette = Palette' PixelRGB8
 -- | Parse a palette from a png chunk.
 parsePalette :: PngRawChunk -> Either String PngPalette
 parsePalette plte
- | chunkLength plte `mod` 3 /= 0 = Left "Invalid palette size"
- | otherwise = Palette' pixelCount . V.fromListN (3 * pixelCount) <$> pixels
-    where pixelUnpacker = replicateM (fromIntegral pixelCount * 3) get
-          pixelCount = fromIntegral $ chunkLength plte `div` 3
+ | plteCount `mod` 3 /= 0 = Left "Invalid palette size"
+ | otherwise = Palette' . V.fromListN plteCount <$> pixels
+    where pixelUnpacker = replicateM plteCount get
+          plteCount = fromIntegral $ chunkLength plte
           pixels = runGet pixelUnpacker (chunkData plte)
 
 -- | Data structure during real png loading/parsing

--- a/src/Codec/Picture/Tga.hs
+++ b/src/Codec/Picture/Tga.hs
@@ -273,11 +273,8 @@ toPaletted :: (Pixel px)
            => (Image Pixel8 -> Palette' px -> PalettedImage) -> Image px
            -> DynamicImage
            -> Either String PalettedImage
-toPaletted f palette (ImageY8 img) = pure $ f img pal where
-  pal = Palette' 
-    { _paletteSize = imageWidth palette
-    , _paletteData = imageData palette
-    }
+toPaletted f palette (ImageY8 img) =
+  pure $ f img Palette' {_paletteData = imageData palette}
 toPaletted _ _ _ = Left "Bad colorspace for image"
 
 unparse :: TgaFile -> Either String (PalettedImage, Metadatas)

--- a/src/Codec/Picture/Tiff.hs
+++ b/src/Codec/Picture/Tiff.hs
@@ -668,10 +668,7 @@ instance BinaryParam B.ByteString TiffInfo where
         <*> pure (extractTiffMetadata cleaned)
 
 palette16Of :: Image PixelRGB16 -> Palette' PixelRGB16
-palette16Of p = Palette'
-    { _paletteSize = imageWidth p
-    , _paletteData = imageData p
-    }
+palette16Of p = Palette' {_paletteData = imageData p}
 
 unpack :: B.ByteString -> TiffInfo -> Either String PalettedImage
 -- | while mandatory some images don't put correct

--- a/src/Codec/Picture/Types.hs
+++ b/src/Codec/Picture/Types.hs
@@ -21,6 +21,7 @@ module Codec.Picture.Types( -- * Types
                           , PalettedImage( .. )
                           , Palette
                           , Palette'( .. )
+                          , paletteSize
 
                             -- ** Image functions
                           , createMutableImage
@@ -407,18 +408,20 @@ data DynamicImage =
 -- | Type used to expose a palette extracted during reading.
 -- Use palettedAsImage to convert it to a palette usable for
 -- writing.
-data Palette' px = Palette'
-  { -- | Number of element in pixels.
-    _paletteSize :: !Int
-    -- | Real data used by the palette.
-  , _paletteData :: !(V.Vector (PixelBaseComponent px))
+newtype Palette' px = Palette'
+  { -- | Real data used by the palette.
+  _paletteData :: V.Vector (PixelBaseComponent px)
   }
   deriving Typeable
 
+-- | Size of pallete in pixels
+paletteSize :: forall px . Pixel px => Palette' px -> Int
+paletteSize = (`div` componentCount (undefined :: px)) . V.length . _paletteData
+
 -- | Convert a palette to an image. Used mainly for
 -- backward compatibility.
-palettedAsImage :: Palette' px -> Image px
-palettedAsImage p = Image (_paletteSize p) 1 $ _paletteData p
+palettedAsImage :: Pixel px => Palette' px -> Image px
+palettedAsImage p = Image (paletteSize p) 1 $ _paletteData p
 
 -- | Describe an image and it's potential associated
 -- palette. If no palette is present, fallback to a


### PR DESCRIPTION
From what I gather `_paletteSize` is an unnecessary field in `Palette'`, since it can be deduced from the size of `_paletteData` and the type of pixel, which is exactly the way that the newly added `paletteSize` is implemented. Couple benefits that come from this change:

* `Palette'` is now a `newtype` around `Vector`, hence slight reduction to memory usage and overall improvement to performance
* Safety improvement: Exposing private `_paletteSize` that is coupled to the actual data allows construction of incorrect `Palette'`, which opens a possibility of a segfault when using images converted from such palettes by `palettedAsImage`