### PR TITLE
Fix the handling of ExifUndefined data of 4 bytes or fewer.

### DIFF
--- a/src/Codec/Picture/Tiff/Internal/Types.hs
+++ b/src/Codec/Picture/Tiff/Internal/Types.hs
@@ -262,9 +262,9 @@ instance BinaryParam (Endianness, Int, ImageFileDirectory) ExifData where
          align ifd $ ExifUndefined <$> getByteString (fromIntegral count)
       fetcher ImageFileDirectory { ifdType = TypeUndefined, ifdOffset = ofs } =
           pure . ExifUndefined . B.pack $ take (fromIntegral $ ifdCount ifd)
-              [fromIntegral $ ofs .&. 0xFF000000 `unsafeShiftR` (3 * 8)
-              ,fromIntegral $ ofs .&. 0x00FF0000 `unsafeShiftR` (2 * 8)
-              ,fromIntegral $ ofs .&. 0x0000FF00 `unsafeShiftR` (1 * 8)
+              [fromIntegral $ (ofs .&. 0xFF000000) `unsafeShiftR` (3 * 8)
+              ,fromIntegral $ (ofs .&. 0x00FF0000) `unsafeShiftR` (2 * 8)
+              ,fromIntegral $ (ofs .&. 0x0000FF00) `unsafeShiftR` (1 * 8)
               ,fromIntegral $ ofs .&. 0x000000FF
               ]
       fetcher ImageFileDirectory { ifdType = TypeAscii, ifdCount = count } | count > 1 =


### PR DESCRIPTION
For example, this was causing the EXIF version (tag 0x9000) to come out as "0000" instead of "0320".

Here is a test program and image which demonstrates the bug: [exif-test-version.zip](https://github.com/Twinside/Juicy.Pixels/files/5008541/exif-test-version.zip)

The compiler was interpreting:

```haskell
              [fromIntegral $ ofs .&. 0xFF000000 `unsafeShiftR` (3 * 8)
              ,fromIntegral $ ofs .&. 0x00FF0000 `unsafeShiftR` (2 * 8)
              ,fromIntegral $ ofs .&. 0x0000FF00 `unsafeShiftR` (1 * 8)
              ,fromIntegral $ ofs .&. 0x000000FF
              ]
```

as:

```haskell
              [fromIntegral $ ofs .&. (0xFF000000 `unsafeShiftR` (3 * 8))
              ,fromIntegral $ ofs .&. (0x00FF0000 `unsafeShiftR` (2 * 8))
              ,fromIntegral $ ofs .&. (0x0000FF00 `unsafeShiftR` (1 * 8))
              ,fromIntegral $ ofs .&. 0x000000FF
              ]
```

which is the same as:

```haskell
              [fromIntegral $ ofs .&. 0x000000FF
              ,fromIntegral $ ofs .&. 0x000000FF
              ,fromIntegral $ ofs .&. 0x000000FF
              ,fromIntegral $ ofs .&. 0x000000FF
              ]
```

i. e. repeating the last byte four times.