### PR TITLE
Fix bug #187.  (Some JPEGs are misidentified as SourceTiff.)

### DIFF
--- a/src/Codec/Picture/Jpg.hs
+++ b/src/Codec/Picture/Jpg.hs
@@ -574,7 +574,7 @@ decodeJpegWithMetadata file = case runGetStrict get file of
        let (st, arr) = decodeBaseline
            jfifMeta = foldMap extractMetadatas $ app0JFifMarker st
            exifMeta = foldMap extractTiffMetadata $ app1ExifMarker st
-           meta = sizeMeta <> jfifMeta <> exifMeta
+           meta = jfifMeta <> exifMeta <> sizeMeta
        in
        (, meta) <$>
            dynamicOfColorSpace (colorSpaceOfState st) imgWidth imgHeight arr
@@ -582,7 +582,7 @@ decodeJpegWithMetadata file = case runGetStrict get file of
        let (st, arr) = decodeProgressive
            jfifMeta = foldMap extractMetadatas $ app0JFifMarker st
            exifMeta = foldMap extractTiffMetadata $ app1ExifMarker st
-           meta = sizeMeta <> jfifMeta <> exifMeta
+           meta = jfifMeta <> exifMeta <> sizeMeta
        in
        (, meta) <$>
            dynamicOfColorSpace (colorSpaceOfState st) imgWidth imgHeight arr


### PR DESCRIPTION
Fixes bug #187 by changing the order of the metadata, so that `SourceJpeg` (in `sizeMeta`) overwrites `SourceTiff` (in `exifMeta`), rather than vice-versa.