### PR TITLE
Fix endianness bug in short ExifString and ExifUndefined.

### DIFF
--- a/src/Codec/Picture/Tiff/Internal/Types.hs
+++ b/src/Codec/Picture/Tiff/Internal/Types.hs
@@ -240,6 +240,16 @@ instance BinaryParam (Endianness, Int, ImageFileDirectory) ExifData where
 
       getVec count = V.replicateM (fromIntegral count)
 
+      immediateBytes ofs =
+        let bytes = [fromIntegral $ (ofs .&. 0xFF000000) `unsafeShiftR` (3 * 8)
+                    ,fromIntegral $ (ofs .&. 0x00FF0000) `unsafeShiftR` (2 * 8)
+                    ,fromIntegral $ (ofs .&. 0x0000FF00) `unsafeShiftR` (1 * 8)
+                    ,fromIntegral $  ofs .&. 0x000000FF
+                    ]
+        in case endianness of
+             EndianLittle -> reverse bytes
+             EndianBig    -> bytes
+
       fetcher ImageFileDirectory { ifdIdentifier = TagExifOffset
                                  , ifdType = TypeLong
                                  , ifdCount = 1 } = do
@@ -262,20 +272,12 @@ instance BinaryParam (Endianness, Int, ImageFileDirectory) ExifData where
          align ifd $ ExifUndefined <$> getByteString (fromIntegral count)
       fetcher ImageFileDirectory { ifdType = TypeUndefined, ifdOffset = ofs } =
           pure . ExifUndefined . B.pack $ take (fromIntegral $ ifdCount ifd)
-              [fromIntegral $ (ofs .&. 0xFF000000) `unsafeShiftR` (3 * 8)
-              ,fromIntegral $ (ofs .&. 0x00FF0000) `unsafeShiftR` (2 * 8)
-              ,fromIntegral $ (ofs .&. 0x0000FF00) `unsafeShiftR` (1 * 8)
-              ,fromIntegral $ ofs .&. 0x000000FF
-              ]
+              (immediateBytes ofs)
       fetcher ImageFileDirectory { ifdType = TypeAscii, ifdCount = count } | count > 4 =
           align ifd $ ExifString <$> getByteString (fromIntegral count)
       fetcher ImageFileDirectory { ifdType = TypeAscii, ifdOffset = ofs } =
           pure . ExifString . B.pack $ take (fromIntegral $ ifdCount ifd)
-              [fromIntegral $ (ofs .&. 0xFF000000) `unsafeShiftR` (3 * 8)
-              ,fromIntegral $ (ofs .&. 0x00FF0000) `unsafeShiftR` (2 * 8)
-              ,fromIntegral $ (ofs .&. 0x0000FF00) `unsafeShiftR` (1 * 8)
-              ,fromIntegral $ ofs .&. 0x000000FF
-              ]
+              (immediateBytes ofs)
       fetcher ImageFileDirectory { ifdType = TypeShort, ifdCount = 2, ifdOffset = ofs } =
           pure . ExifShorts $ V.fromListN 2 valList
             where high = fromIntegral $ ofs `unsafeShiftR` 16


### PR DESCRIPTION
When `ExifString` and `ExifUndefined` are four bytes or fewer, they are packed into the "offset" field.  Since string and undefined are byte-oriented, they should appear in sequential order in the file and do not need to be byte-swapped.  However, the `ifdOffset` field has already been byte-swapped.  Therefore, for little-endian files, we need to swap `ifdOffset` back to undo the byte swapping.

A symptom was that ExifVersion was showing up as "0320", although there is no version 3.2 of EXIF, and exiftool shows the version correctly as "0230":

```
$ exif-test
Just (ExifUndefined "0320")
$ exiftool -ExifVersion test-image.jpg
Exif Version                    : 0230
```

After this fix, JuicyPixels correctly reports version "0230":

```
$ exif-test
Just (ExifUndefined "0230")
```

Test program and image which demonstrate the problem: [exif-test-version.zip](https://github.com/Twinside/Juicy.Pixels/files/5008541/exif-test-version.zip)