### PR TITLE
Support bytestring-0.11

### DIFF
--- a/JuicyPixels.cabal
+++ b/JuicyPixels.cabal
@@ -130,7 +130,7 @@ Library
 
   Ghc-options: -O3 -Wall
   Build-depends: base                >= 4.8     && < 6,
-                 bytestring          >= 0.9     && < 0.11,
+                 bytestring          >= 0.9     && < 0.12,
                  mtl                 >= 1.1     && < 2.3,
                  binary              >= 0.8.1     && < 0.9,
                  zlib                >= 0.5.3.1 && < 0.7,

--- a/src/Codec/Picture/Bitmap.hs
+++ b/src/Codec/Picture/Bitmap.hs
@@ -517,7 +517,11 @@ makeBitfield mask = Bitfield mask shiftBits scale
 
 -- | Helper method to cast a 'B.ByteString' to a 'VS.Vector' of some type.
 castByteString :: VS.Storable a => B.ByteString -> VS.Vector a
+#if MIN_VERSION_bytestring(0,11,0)
+castByteString (BI.BS fp len) = VS.unsafeCast $ VS.unsafeFromForeignPtr fp 0 len
+#else
 castByteString (BI.PS fp offset len) = VS.unsafeCast $ VS.unsafeFromForeignPtr fp offset len
+#endif
 
 decodeImageRGBA8 :: RGBABmpFormat -> BmpV5Header -> B.ByteString -> Image PixelRGBA8
 decodeImageRGBA8 pixelFormat (BmpV5Header { width = w, height = h, bitPerPixel = bpp }) str = Image wi hi stArray where

--- a/src/Codec/Picture/VectorByteConversion.hs
+++ b/src/Codec/Picture/VectorByteConversion.hs
@@ -21,12 +21,19 @@ import qualified Data.ByteString.Internal as S
 
 import Codec.Picture.Types
 
+mkBS :: ForeignPtr Word8 -> Int -> Int -> S.ByteString
+#if MIN_VERSION_bytestring(0,11,0)
+mkBS fptr off = S.BS (fptr `S.plusForeignPtr` off)
+#else
+mkBS = S.PS
+#endif
+
 blitVector :: Vector Word8 -> Int -> Int -> B.ByteString
-blitVector vec atIndex = S.PS ptr (offset + atIndex)
+blitVector vec atIndex = mkBS ptr (offset + atIndex)
   where (ptr, offset, _length) = unsafeToForeignPtr vec
 
 toByteString :: forall a. (Storable a) => Vector a -> B.ByteString
-toByteString vec = S.PS (castForeignPtr ptr) offset (len * size)
+toByteString vec = mkBS (castForeignPtr ptr) offset (len * size)
   where (ptr, offset, len) = unsafeToForeignPtr vec
         size = sizeOf (undefined :: a)
 


### PR DESCRIPTION
Tested using 
```cabal
packages: .
tests: true

constraints:
  bytestring < 0.11,
  cassava -bytestring--lt-0_10_4

source-repository-package
  type: git
  location: https://github.com/haskell/attoparsec

source-repository-package
  type: git
  location: https://github.com/Minoru/zlib
  tag: a1b6bcef25774e93be6c3caaf8d99d805242110c

allow-newer:
  cassava:bytestring,
  text-short:bytestring,
  uuid-types:bytestring
```