### PR TITLE
Remove >= from Cabal-version

### DIFF
--- a/JuicyPixels.cabal
+++ b/JuicyPixels.cabal
@@ -16,7 +16,7 @@ Stability:           Stable
 Build-type:          Simple
 
 -- Constraint on the version of Cabal needed to build this package.
-Cabal-version:       >= 1.18
+Cabal-version:       1.18
 
 extra-source-files: changelog, docimages/*.png, docimages/*.svg, README.md
 extra-doc-files: docimages/*.png, docimages/*.svg


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: JuicyPixels.cabal:19:29: Packages with 'cabal-version: 1.12' or later
should specify a specific version of the Cabal spec of the form
'cabal-version: x.y'. Use 'cabal-version: 1.18'.
```