### PR TITLE
Fix JPEG parsing regression

### DIFF
--- a/src/Codec/Picture/Jpg/Internal/Types.hs
+++ b/src/Codec/Picture/Jpg/Internal/Types.hs
@@ -30,6 +30,7 @@ module Codec.Picture.Jpg.Internal.Types( MutableMacroBlock
                               , JFifUnit( .. )
                               , TableList( .. )
                               , RestartInterval( .. )
+                              , getJpgImage
                               , calculateSize
                               , dctBlockSize
                               , parseECS
@@ -454,12 +455,21 @@ instance Binary JpgImage where
         putWord8 0xFF >> putWord8 0xD8 >> mapM_ putFrame frames
             >> putWord8 0xFF >> putWord8 0xD9
 
+    -- | Consider using `getJpgImage` instead for a non-semi-lazy implementation.
     get = do
         skipUntilFrames
         frames <- parseFramesSemiLazy
         -- let endOfImageMarker = 0xD9
         {-checkMarker commonMarkerFirstByte endOfImageMarker-}
         return JpgImage { jpgFrame = frames }
+
+-- | Like `get` from `instance Binary JpgImage`, but without the legacy
+-- semi-lazy implementation.
+getJpgImage :: Get JpgImage
+getJpgImage = do
+    skipUntilFrames
+    frames <- parseFrames
+    return JpgImage { jpgFrame = frames }
 
 skipUntilFrames :: Get ()
 skipUntilFrames = do

--- a/src/Codec/Picture/Jpg/Internal/Types.hs
+++ b/src/Codec/Picture/Jpg/Internal/Types.hs
@@ -67,6 +67,7 @@ import qualified Data.Vector.Storable.Mutable as M
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Lazy as L
+import qualified Data.ByteString.Unsafe as BU
 
 import Data.Int( Int16 )
 import Data.Word(Word8, Word16 )
@@ -622,7 +623,7 @@ parseECS = do
             loop !v !offset_in_chunk
                 | offset_in_chunk >= B.length chunk = Left (v, chunk)
                 | otherwise =
-                    let !vNext = B.index chunk offset_in_chunk
+                    let !vNext = BU.unsafeIndex chunk offset_in_chunk -- bounds check is done above
                         !isReset = 0xD0 <= vNext && vNext <= 0xD7
                         !vIsSegmentMarker = v == 0xFF && vNext /= 0 && not isReset
                     in

--- a/src/Codec/Picture/Jpg/Internal/Types.hs
+++ b/src/Codec/Picture/Jpg/Internal/Types.hs
@@ -603,7 +603,11 @@ parseECS = do
     -- so that we can set `consumed` properly, because this function is supposed
     -- to not consume the start of the segment marker (see code dropping the last
     -- byte of the previous chunk below).
-    GetInternal.withInputChunks (v_first, B.empty) consumeChunk (L.fromChunks . (B.singleton v_first :)) (return . L.fromChunks . (B.singleton v_first :)) -- `v_first` also belongs to the returned BS
+    GetInternal.withInputChunks
+        (v_first, B.empty)
+        consumeChunk
+        (         L.fromChunks . (B.singleton v_first :)) -- `v_first` also belongs to the returned BS
+        (return . L.fromChunks . (B.singleton v_first :)) -- `v_first` also belongs to the returned BS
   where
     consumeChunk :: GetInternal.Consume (Word8, B.ByteString) -- which is: (Word8, B.ByteString) -> B.ByteString -> Either (Word8, B.ByteString) (B.ByteString, B.ByteString)
     consumeChunk (!v_chunk_start, !prev_chunk) !chunk

--- a/test-src/main.hs
+++ b/test-src/main.hs
@@ -12,6 +12,7 @@ import Codec.Picture.Gif
 import Codec.Picture.Tiff
 import System.Environment
 
+import Data.Either ( isRight )
 import Data.Binary
 import Data.Binary.Get (runGetOrFail)
 import Data.Bits ( unsafeShiftR, xor )
@@ -812,28 +813,36 @@ palettedPngCreation = L.writeFile "tests/paleted_alpha.png" encoded
     palette :: Image PixelRGBA8
     palette = generateImage (\x _y -> PixelRGBA8 255 128 128 (255 - fromIntegral x)) 256 1
 
-jpgParseECS_equivalence :: FilePath -> IO ()
-jpgParseECS_equivalence path = do
+-- The given `path` must be a valid JPEG; this function checks it.
+-- This is to guard against not noticing that everything fails parsing.
+jpgParseECS_equivalence_success :: FilePath -> IO ()
+jpgParseECS_equivalence_success path = do
     bsl <- L.fromStrict <$> B.readFile path
-    let ecs =
-            runGetOrFail (parseFramesWithParseECSFunction JpgInternal.parseECS) bsl
-    let ecs_simple =
-            runGetOrFail (parseFramesWithParseECSFunction JpgInternal.parseECS_simple) bsl
-    when (ecs /= ecs_simple) $ do
-        error "Test failure: parseECS /= parseECS_simple"
+    let ecs_res =
+            runGetOrFail (JpgInternal.skipUntilFrames *> parseFramesWithParseECSFunction JpgInternal.parseECS) bsl
+    let ecs_simple_res =
+            runGetOrFail (JpgInternal.skipUntilFrames *> parseFramesWithParseECSFunction JpgInternal.parseECS_simple) bsl
+    case (ecs_res, ecs_simple_res) of
+        (Right{}, Right{})
+            | ecs_res == ecs_simple_res -> return ()
+            | otherwise -> error "Test failure: parseECS /= parseECS_simple"
+        _ -> error $ "Test failure: parseECS / parseECS_simple failed unexpectedly with results: " ++ show (isRight ecs_res, isRight ecs_simple_res) -- only show Left/Right
   where
     parseFramesWithParseECSFunction :: Get L.ByteString -> Get [JpgInternal.JpgFrame]
     parseFramesWithParseECSFunction parseECSFunction = do
         kind <- get
-        mbFrame <- case kind of
-            JpgInternal.JpgStartOfScan -> do
-                scanHeader <- get
-                ecs <- parseECSFunction
-                return $! Just $! JpgInternal.JpgScanBlob scanHeader ecs
-            _ -> JpgInternal.parseFrameOfKind kind
-        JpgInternal.skipFrameMarker
-        remainingFrames <- JpgInternal.parseFrames
-        return $ maybeToList mbFrame ++ remainingFrames
+        case kind of
+            JpgInternal.JpgEndOfImage -> return []
+            _ -> do
+                mbFrame <- case kind of
+                    JpgInternal.JpgStartOfScan -> do
+                        scanHeader <- get
+                        ecs <- parseECSFunction
+                        return $! Just $! JpgInternal.JpgScanBlob scanHeader ecs
+                    _ -> JpgInternal.parseFrameOfKind kind
+                JpgInternal.skipFrameMarker
+                remainingFrames <- JpgInternal.parseFrames
+                return $ maybeToList mbFrame ++ remainingFrames
 
 testSuite :: IO ()
 testSuite = do
@@ -847,7 +856,7 @@ testSuite = do
     putStrLn ">>>> Gif palette test"
     gifPaletteTest
     putStrLn ">>>> Jpg parseECS equivalence test"
-    mapM_ (jpgParseECS_equivalence . (("tests" </> "jpeg") </>)) ("huge.jpg" : "10x8-samsung-s8.jpg" : jpegValidTests)
+    mapM_ (jpgParseECS_equivalence_success . (("tests" </> "jpeg") </>)) ("huge.jpg" : "10x8-samsung-s8.jpg" : jpegValidTests)
     putStrLn ">>>> Valid instances"
     toJpg "white" $ generateImage (\_ _ -> PixelRGB8 255 255 255) 16 16
     toJpg "black" $ generateImage (\_ _ -> PixelRGB8 0 0 0) 16 16


### PR DESCRIPTION
This should fix the regression from https://github.com/Twinside/Juicy.Pixels/pull/215#issuecomment-1339068368.

I made a couple mistakes there.

I improved the equivalence test (which was not correct), and further confirmed it against the old implementation in my separate branch [`jpeg-parsing-fixes-2-investigation`](https://github.com/nh2/Juicy.Pixels/tree/jpeg-parsing-fixes-2-investigation) with commit https://github.com/Twinside/Juicy.Pixels/commit/054d76bac8b92c30210057b9d785cb33fa821f2c.

---

I also want to point out (beyond issue #214) that the test suite as it is now is totally insufficient, because it does not catch even the most severe errors like JPEGs not parsing correctly at all. That makes it difficult to contribute performance fixes like #215 with confidence.