### PR TITLE
Future-proof against potential Prelude.foldl'

### DIFF
--- a/src/Codec/Picture/Metadata.hs
+++ b/src/Codec/Picture/Metadata.hs
@@ -43,6 +43,8 @@ module Codec.Picture.Metadata( -- * Types
                              , dotsPerCentiMeterToDotPerInch
                              ) where
 
+import Prelude hiding (Foldable(..))
+
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid( Monoid, mempty, mappend )
 import Data.Word( Word )


### PR DESCRIPTION
See https://github.com/haskell/core-libraries-committee/issues/167

This is, of course, a bit speculative at the moment, but given that the change does not involve CPP, it should not hurt to merge it early to simplify further impact assessment.