### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Status
         - 8 and 16 bits
         - CMYK, YCbCr, RGB, RGBA, Greyscale
         - Uncompressed
-    * Metadata: reading DpiX, DpiY and EXIF informations.
+    * Metadata: reading DpiX, DpiY and EXIF information.
 
 _I love juicy pixels_
 

--- a/changelog
+++ b/changelog
@@ -98,7 +98,7 @@ v3.2.9.4 January 2018
 v3.2.9.3 December 2017
 ----------------------
 
- * Fix: remove bad invisible unicde char
+ * Fix: remove bad invisible unicode char
 
 v3.2.9.2 December 2017
 ----------------------
@@ -175,7 +175,7 @@ v3.2.6.3 November 2015
 
 v3.2.6.2 November 2015
 ----------------------
- * Fix: Using minimal GIF version if outputing a single image.
+ * Fix: Using minimal GIF version if outputting a single image.
 
 v3.2.6.1 August 2015
 --------------------
@@ -197,7 +197,7 @@ V3.2.5.3 July 2015
 V3.2.5.2 June 2015
 ------------------
 
- * Adding: Width & Height metdata to help querying image information
+ * Adding: Width & Height metadata to help querying image information
 	without decompressing the whole.
  * Adding: Source format metadata.
 
@@ -263,7 +263,7 @@ v3.2 December 2014
 v3.1.7.1 August 2014
 --------------------
 
- * Previous gif fix was not working withing the readImage
+ * Previous gif fix was not working within the readImage
    function, only in specialized gif images. Correcting
    miscorection
 
@@ -287,7 +287,7 @@ v3.1.6 August 2014
 
  * Fix bad disposal handling in GIF animations.
  * Added ColorConvertible instance for PixelRGB8 -> PixelRGBA16 (KaiHa)
- * Fixing a bad handling of tRNS causing bad transprency decoding in
+ * Fixing a bad handling of tRNS causing bad transparency decoding in
    some circonstances.
  * Adding the concept of Packeable pixel for faster pixel filling
    using mutable array.
@@ -379,9 +379,9 @@ v3.1.1.1 October 2013
 v3.1.1  October 2013
 --------------------
 
- * Adding uncompresed TIFF saving.
+ * Adding uncompressed TIFF saving.
  * Adding error message to avoid loading progressive loading.
- * Made MMAP optional, controled by a cabal flag.
+ * Made MMAP optional, controlled by a cabal flag.
  * adding dynamicPixelMap helper function.
  * Handling png transparency using color key (#26).
 

--- a/src/Codec/Picture/BitWriter.hs
+++ b/src/Codec/Picture/BitWriter.hs
@@ -92,7 +92,7 @@ setDecodedString str = case B.uncons str of
      Nothing        -> S.put $ BoolState      0 0 B.empty
      Just (v, rest) -> S.put $ BoolState      0 v    rest
 
--- | Drop all bit until the bit of indice 0, usefull to parse restart
+-- | Drop all bit until the bit of indice 0, useful to parse restart
 -- marker, as they are byte aligned, but Huffman might not.
 byteAlignJpg :: BoolReader s ()
 byteAlignJpg = do

--- a/src/Codec/Picture/ColorQuant.hs
+++ b/src/Codec/Picture/ColorQuant.hs
@@ -41,7 +41,7 @@ import           Codec.Picture.Gif (GifFrame(..), GifDisposalMethod, GifDelay)
 
 -- | Define which palette creation method is used.
 data PaletteCreationMethod =
-      -- | MedianMeanCut method, provide the best results (visualy)
+      -- | MedianMeanCut method, provide the best results (visually)
       -- at the cost of increased calculations.
       MedianMeanCut
       -- | Very fast algorithm (one pass), doesn't provide good
@@ -282,7 +282,7 @@ intLength = Fold (\n _ -> n + 1) 0 id
 -- We use the product of volume and population to determine the next cluster
 -- to split and determine the placement of each color by compating it to the
 -- mean of the parent cluster. So median cut is a bit of a misnomer, since one
--- of the modifiations is to use the mean.
+-- of the modifications is to use the mean.
 
 mkPaletteVec :: [Cluster] -> Vector PixelRGB8
 mkPaletteVec  = V.fromList . map (toRGB8 . meanColor)

--- a/src/Codec/Picture/ConvGraph.hs
+++ b/src/Codec/Picture/ConvGraph.hs
@@ -1,6 +1,6 @@
 -- $graph
 --
--- The following graph describe the differents way to convert between pixel types,
+-- The following graph describe the different way to convert between pixel types,
 --
 -- * Nodes describe pixel type
 --

--- a/src/Codec/Picture/Gif.hs
+++ b/src/Codec/Picture/Gif.hs
@@ -83,7 +83,7 @@ data GifLooping =
       LoopingNever
       -- | The animation will restart once the end is reached
     | LoopingForever
-      -- | The animation will repeat n times before stoping
+      -- | The animation will repeat n times before stopping
     | LoopingRepeat Word16
 
 

--- a/src/Codec/Picture/HDR.hs
+++ b/src/Codec/Picture/HDR.hs
@@ -51,7 +51,7 @@ import Codec.Picture.VectorByteConversion
 #if MIN_VERSION_transformers(0, 4, 0)
 import Control.Monad.Trans.Except( ExceptT, throwE, runExceptT )
 #else
--- Transfomers 0.3 compat
+-- Transformers 0.3 compat
 import Control.Monad.Trans.Error( Error, ErrorT, throwError, runErrorT )
 
 type ExceptT = ErrorT
@@ -179,7 +179,7 @@ decodeInfos = do
 decodeHDR :: B.ByteString -> Either String DynamicImage
 decodeHDR = fmap fst . decodeHDRWithMetadata
 
--- | Equivalent to decodeHDR but with aditional metadatas.
+-- | Equivalent to decodeHDR but with additional metadatas.
 decodeHDRWithMetadata :: B.ByteString -> Either String (DynamicImage, Metadatas)
 decodeHDRWithMetadata str = runST $ runExceptT $
   case runGet decodeHeader $ L.fromChunks [str] of

--- a/src/Codec/Picture/Jpg.hs
+++ b/src/Codec/Picture/Jpg.hs
@@ -740,7 +740,7 @@ prepareHuffmanTable classVal dest tableDef =
                         }, VS.singleton 0)
       where sizes = VU.fromListN 16 $ map (fromIntegral . length) tableDef
 
--- | Encode an image in jpeg at a reasonnable quality level.
+-- | Encode an image in jpeg at a reasonable quality level.
 -- If you want better quality or reduced file size, you should
 -- use `encodeJpegAtQuality`
 encodeJpeg :: Image PixelYCbCr8 -> L.ByteString
@@ -780,7 +780,7 @@ encodeJpegAtQuality quality = encodeJpegAtQualityWithMetadata quality mempty
 
 -- | Record gathering all information to encode a component
 -- from the source image. Previously was a huge tuple
--- burried in the code
+-- buried in the code
 data EncoderState = EncoderState
   { _encComponentIndex :: !Int
   , _encBlockWidth     :: !Int

--- a/src/Codec/Picture/Jpg/Internal/DefaultTable.hs
+++ b/src/Codec/Picture/Jpg/Internal/DefaultTable.hs
@@ -99,7 +99,7 @@ makeInverseTable t = V.replicate 255 (0,0) V.// inner 0 0 t
             where shifted = code `unsafeShiftL` 1
 
 -- | Represent a compact array of 8 * 8 values. The size
--- is not guarenteed by type system, but if makeMacroBlock is
+-- is not guaranteed by type system, but if makeMacroBlock is
 -- used, everything should be fine size-wise
 type MacroBlock a = SV.Vector a
 

--- a/src/Codec/Picture/Metadata.hs
+++ b/src/Codec/Picture/Metadata.hs
@@ -80,7 +80,7 @@ instance NFData SourceFormat where
   rnf a = a `seq` ()
 
 -- | The same color values may result in slightly different colors on different
--- devices. To get consistent colors accross multiple devices we need a way of
+-- devices. To get consistent colors across multiple devices we need a way of
 -- mapping color values from a source device into their equivalents on the
 -- target device.
 --
@@ -129,7 +129,7 @@ instance NFData ColorSpace where
 --   * 'ColorProfile' An unparsed ICC color profile. Currently only supported by
 --          the Bitmap format.
 --
---   * 'Unknown' unlikely to be decoded, but usefull for metadata writing
+--   * 'Unknown' unlikely to be decoded, but useful for metadata writing
 --
 --   * 'Exif' Exif tag and associated data.
 --

--- a/src/Codec/Picture/Metadata/Exif.hs
+++ b/src/Codec/Picture/Metadata/Exif.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 
--- | This module provide a totally partial and incomplete maping
+-- | This module provide a totally partial and incomplete mapping
 -- of Exif values. Used for Tiff parsing and reused for Exif extraction.
 module Codec.Picture.Metadata.Exif ( ExifTag( .. )
                                    , ExifData( .. )
@@ -18,7 +18,7 @@ import qualified Data.Vector as V
 import qualified Data.ByteString as B
 import GHC.Generics( Generic )
 
--- | Tag values used for exif fields. Completly incomplete
+-- | Tag values used for exif fields. Completely incomplete
 data ExifTag
   = TagPhotometricInterpretation
   | TagCompression -- ^ Short type

--- a/src/Codec/Picture/Png.hs
+++ b/src/Codec/Picture/Png.hs
@@ -498,7 +498,7 @@ decodePng = fmap fst . decodePngWithMetadata
 decodePngWithMetadata :: B.ByteString -> Either String (DynamicImage, Metadatas)
 decodePngWithMetadata b = first palettedToTrueColor <$> decodePngWithPaletteAndMetadata b
 
--- | Same as 'decodePng' but also extract meta datas present
+-- | Same as 'decodePng' but also extract meta data present
 -- in the files.
 decodePngWithPaletteAndMetadata :: B.ByteString -> Either String (PalettedImage, Metadatas)
 decodePngWithPaletteAndMetadata byte =  do

--- a/src/Codec/Picture/Png/Internal/Export.hs
+++ b/src/Codec/Picture/Png/Internal/Export.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ScopedTypeVariables #-}
--- | Module implementing a basic png export, no filtering is applyed, but
+-- | Module implementing a basic png export, no filtering is applied, but
 -- export at least valid images.
 module Codec.Picture.Png.Internal.Export( PngSavable( .. )
                                , PngPaletteSaveable( .. )
@@ -93,11 +93,11 @@ class PngSavable a where
     --  * 'Codec.Picture.Metadata.Warning'
     --  * 'Codec.Picture.Metadata.Unknown' using the key present in the constructor.
     -- 
-    -- the followings metadata will be stored in the `gAMA` chunk.
+    -- the following metadata will be stored in the `gAMA` chunk.
     --
     --  * 'Codec.Picture.Metadata.Gamma'
     --
-    -- The followings metadata will be stored in a `pHYs` chunk
+    -- The following metadata will be stored in a `pHYs` chunk
     --
     --  * 'Codec.Picture.Metadata.DpiX'
     --  * 'Codec.Picture.Metadata.DpiY' 

--- a/src/Codec/Picture/Png/Internal/Type.hs
+++ b/src/Codec/Picture/Png/Internal/Type.hs
@@ -381,7 +381,7 @@ iHDRSignature :: ChunkSignature
 iHDRSignature = signature "IHDR"
 
 -- | Signature for a palette chunk in the pgn file. Must
--- occure before iDAT.
+-- occurred before iDAT.
 pLTESignature :: ChunkSignature
 pLTESignature = signature "PLTE"
 

--- a/src/Codec/Picture/Tga.hs
+++ b/src/Codec/Picture/Tga.hs
@@ -460,7 +460,7 @@ decodeTga byte = fst <$> decodeTgaWithMetadata byte
 decodeTgaWithMetadata :: B.ByteString -> Either String (DynamicImage, Metadatas)
 decodeTgaWithMetadata byte = first palettedToTrueColor <$> decodeTgaWithPaletteAndMetadata byte
 
--- | Equivalent to decodeTga but with metdata and palette if any
+-- | Equivalent to decodeTga but with metadata and palette if any
 decodeTgaWithPaletteAndMetadata :: B.ByteString -> Either String (PalettedImage, Metadatas)
 decodeTgaWithPaletteAndMetadata byte = runGetStrict get byte >>= unparse
 

--- a/src/Codec/Picture/Tiff.hs
+++ b/src/Codec/Picture/Tiff.hs
@@ -817,11 +817,11 @@ unpack _ _ = Left "Failure to unpack TIFF file"
 decodeTiff :: B.ByteString -> Either String DynamicImage
 decodeTiff = fmap fst . decodeTiffWithMetadata 
 
--- | Like 'decodeTiff' but also provides some metdata present
+-- | Like 'decodeTiff' but also provides some metadata present
 -- in the Tiff file.
 --
 -- The metadata extracted are the 'Codec.Picture.Metadata.DpiX' &
--- 'Codec.Picture.Metadata.DpiY' information alongside the EXIF informations.
+-- 'Codec.Picture.Metadata.DpiY' information alongside the EXIF information.
 decodeTiffWithMetadata :: B.ByteString -> Either String (DynamicImage, Metadatas)
 decodeTiffWithMetadata str = first palettedToTrueColor <$> decodeTiffWithPaletteAndMetadata str
 

--- a/src/Codec/Picture/Tiff/Internal/Types.hs
+++ b/src/Codec/Picture/Tiff/Internal/Types.hs
@@ -359,11 +359,11 @@ instance BinaryParam B.ByteString (TiffHeader, [[ImageFileDirectory]]) where
     put hdr
     putByteString rawData
     let endianness = hdrEndianness hdr
-        (_, offseted) = mapAccumL
+        (_, offsetted) = mapAccumL
             (\ix ifd -> setupIfdOffsets ix $ orderIfdByTag ifd)
             (hdrOffset hdr)
             ifds
-    forM_ offseted $ \list -> do
+    forM_ offsetted $ \list -> do
         putP endianness list
         mapM_ (\field -> putP (endianness, (0::Int), field) $ ifdExtended field) list
 

--- a/src/Codec/Picture/Types.hs
+++ b/src/Codec/Picture/Types.hs
@@ -467,7 +467,7 @@ dynamicMap f (ImageCMYK8 i) = f i
 dynamicMap f (ImageCMYK16 i) = f i
 
 -- | Equivalent of the `pixelMap` function for the dynamic images.
--- You can perform pixel colorspace independant operations with this
+-- You can perform pixel colorspace independent operations with this
 -- function.
 --
 -- For instance, if you want to extract a square crop of any image,
@@ -742,12 +742,12 @@ class ( Storable (PixelBaseComponent a)
     -- it is treated like the other color components.
     colorMap :: (PixelBaseComponent a -> PixelBaseComponent a) -> a -> a
 
-    -- | Calculate the index for the begining of the pixel
+    -- | Calculate the index for the beginning of the pixel
     pixelBaseIndex :: Image a -> Int -> Int -> Int
     pixelBaseIndex (Image { imageWidth = w }) x y =
             (x + y * w) * componentCount (undefined :: a)
 
-    -- | Calculate theindex for the begining of the pixel at position x y
+    -- | Calculate theindex for the beginning of the pixel at position x y
     mutablePixelBaseIndex :: MutableImage s a -> Int -> Int -> Int
     mutablePixelBaseIndex (MutableImage { mutableImageWidth = w }) x y =
             (x + y * w) * componentCount (undefined :: a)
@@ -1188,7 +1188,7 @@ instance LumaPlaneExtractable PixelYCbCr8 where
     computeLuma (PixelYCbCr8 y _ _) = y
     extractLumaPlane = extractComponent PlaneLuma
 
--- | Free promotion for identic pixel types
+-- | Free promotion for identical pixel types
 instance (Pixel a) => ColorConvertible a a where
     {-# INLINE promotePixel #-}
     promotePixel = id
@@ -2404,7 +2404,7 @@ toneMapping exposure img = Image (imageWidth img) (imageHeight img) scaledData
 -- to pack a pixel value to a simpler "primitive" data
 -- type to allow faster writing to moemory.
 class PackeablePixel a where
-    -- | Primitive type asociated to the current pixel
+    -- | Primitive type associated to the current pixel
     -- It's Word32 for PixelRGBA8 for instance
     type PackedRepresentation a
 


### PR DESCRIPTION
Found via `codespell  -S tests -L padd,bu,paeth,writen,readed,extrems,dividor`